### PR TITLE
Disable form-submit when hitting Enter

### DIFF
--- a/app/javascript/controllers/refine/update-controller.js
+++ b/app/javascript/controllers/refine/update-controller.js
@@ -107,4 +107,12 @@ export default class extends FormController {
     state.replaceCriterion(criterionIdValue, newConditionId, config)
     this.submitForm()
   }
+
+  // Prevent form submission when hitting enter in a text box
+  cancelEnter(event) {
+    if (event.code === "Enter") {
+      event.preventDefault()
+      event.stopPropagation()
+    }
+  }
 }

--- a/app/views/hammerstone/refine_blueprints/clauses/_text_condition.html.erb
+++ b/app/views/hammerstone/refine_blueprints/clauses/_text_condition.html.erb
@@ -11,7 +11,7 @@
       name="<%= condition[:id] %>"
       type="text"
       value="<%= input[:value] %>"
-      data-action="input->refine--update#updateBlueprint"
+      data-action="input->refine--update#updateBlueprint keydown->refine--update#cancelEnter"
     />
 
     <% # any error messages. %>


### PR DESCRIPTION
This PR disables form submission when hitting enter.  This fixes the timing issue where the filter state would sometimes reset after hitting enter in a text box.