### PR TITLE
CSRF meta tag not present in test ENV

### DIFF
--- a/app/javascript/controllers/refine/update-controller.js
+++ b/app/javascript/controllers/refine/update-controller.js
@@ -83,7 +83,7 @@ export default class extends FormController {
     // Create stableId on debounced input and update stable id to allow for form submission
     const { state } = this
     let post_data = JSON.stringify({ blueprint, filter })
-    let token = document.querySelector("meta[name='csrf-token']").content
+    let token = document.querySelector("meta[name='csrf-token']")?.content
     $.ajax({
       type: 'PUT',
       url: '/hammerstone/update_stable_id',


### PR DESCRIPTION
Rails doesn't write out CSRF tokens in the test environment.  This PR allows the update controller to work when they're not there.