### PR TITLE
Dynamically resolve stabilizer classes

### DIFF
--- a/app/controllers/hammerstone/refine/stored_filters_controller.rb
+++ b/app/controllers/hammerstone/refine/stored_filters_controller.rb
@@ -99,7 +99,7 @@ module Hammerstone::Refine
 
     def refine_filter
       if stable_id
-        Stabilizers::UrlEncodedStabilizer.new.from_stable_id(id: stable_id)
+        Hammerstone.stabilizer_class('Stabilizers::UrlEncodedStabilizer').new.from_stable_id(id: stable_id)
       elsif filter_class
         filterClass = filter_class.constantize
         filterClass.new []

--- a/app/controllers/hammerstone/refine_blueprints_controller.rb
+++ b/app/controllers/hammerstone/refine_blueprints_controller.rb
@@ -14,7 +14,7 @@ class Hammerstone::RefineBlueprintsController < Account::ApplicationController
     # in the show method they are a string. 
     blueprint_details = params.to_unsafe_h[:blueprint]
     filter = filterClass.new blueprint_details
-    filter_id = Stabilizers::UrlEncodedStabilizer.new.to_stable_id(filter: filter)
+    filter_id = Hammerstone.stabilizer_class('Stabilizers::UrlEncodedStabilizer').new.to_stable_id(filter: filter)
     render json: { filter_id: filter_id }, status: :ok
   end
 
@@ -22,7 +22,7 @@ class Hammerstone::RefineBlueprintsController < Account::ApplicationController
 
   def filter
     if stable_id
-      Stabilizers::UrlEncodedStabilizer.new.from_stable_id(id: stable_id)
+      Hammerstone.stabilizer_class('Stabilizers::UrlEncodedStabilizer').new.from_stable_id(id: stable_id)
     else
       filterClass = filter_params[:filter].constantize
       filterClass.new blueprint

--- a/app/models/hammerstone.rb
+++ b/app/models/hammerstone.rb
@@ -1,0 +1,12 @@
+module Hammerstone
+  def stabilizer_class(class_name)
+    my_class_name = if ENV['NAMESPACE_REFINE_STABILIZERS']
+                      'Hammerstone::Refine::' + class_name
+                    else
+                      class_name
+                    end
+
+    my_class_name.constantize
+  end
+  module_function :stabilizer_class
+end

--- a/app/models/hammerstone/refine/conditions/filter_condition.rb
+++ b/app/models/hammerstone/refine/conditions/filter_condition.rb
@@ -73,7 +73,7 @@ module Hammerstone::Refine::Conditions
 
     def apply_condition(input, table)
       filter_id = input[:selected].first.to_i
-      filter = Stabilizers::DatabaseStabilizer.new.from_stable_id(id: filter_id)
+      filter = Hammerstone.stabilizer_class('Stabilizers::DatabaseStabilizer').new.from_stable_id(id: filter_id)
       # TODO handle this more elegantly
       raise "Filter not found" if filter.blank?
       # TODO - Filter initial query is currently handled on the filter class. ProductFilter.where....

--- a/app/models/hammerstone/refine/stored_filter.rb
+++ b/app/models/hammerstone/refine/stored_filter.rb
@@ -9,7 +9,7 @@ module Hammerstone::Refine
     end
 
     def refine_filter
-      Stabilizers::DatabaseStabilizer.new.from_stable_id(id: id)
+      Hammerstone.stabilizer_class('Stabilizers::DatabaseStabilizer').new.from_stable_id(id: id)
     end
   end
 end


### PR DESCRIPTION
This PR eliminates the need to edit the `refine-rails` source code to namespace stabilizer class names

It adds the `Hammerstone.stabilizer_class` method, which will resolve Stabilizer class names based on the presences of the `NAMESPACE_REFINE_STABILIZERS` ENV variable.

if `NAMESPACE_REFINE_STABILIZERS` is present in ENV, the class from the `Hammerstone::Refine::` namespace is returned.

If the ENV var is not present, the unnamespaced class is returned.

This should continue to work without any modification to the client app.

I'll post a PR to the bullet_train_test_refine_npm_package repo to auto-set the ENV var.