### PR TITLE
Add refine to BT linked gems so our tailwind styles get included in CSS

### DIFF
--- a/lib/refine/rails/engine.rb
+++ b/lib/refine/rails/engine.rb
@@ -1,6 +1,12 @@
 module Refine
   module Rails
     class Engine < ::Rails::Engine
+      initializer "refine-rails.register" do |app|
+        begin
+          BulletTrain.linked_gems << "refine-rails"
+        rescue NameError
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds our gem to Bullet Train's list of "linked gems".  This means that BT will maintain a copy of our gem's code in tmp/gems, which the tailwind JIT will scan when generating CSS files.

This fixes display issues due to missing styles.