### PR TITLE
Use Themify icon for delete button

### DIFF
--- a/app/views/hammerstone/refine_blueprints/_criterion.html.erb
+++ b/app/views/hammerstone/refine_blueprints/_criterion.html.erb
@@ -48,7 +48,7 @@
     <%= button_tag type: 'submit', class: 'ml-auto flex items-center', data: {
       action: "click->refine--delete#criterion",
     } do %>
-      <i class="text-gray-600 fas fa-trash-alt"></i>
+      <i class="text-gray-600 ti ti-trash"></i>
       <span class="text-black-500 pl-2 hidden">Remove filter</span>
     <% end %>
   <% end %>


### PR DESCRIPTION
This PR fixes the missing delete buttons in the `bullet_train_test_refine_npm_package` repo. The button wasn't showing up because Bullet Train only uses Font Awesome if Pro is configured. In other cases it falls back to Themify icons so it's probably safer to use that.
