### PR TITLE
WIP: DO NOT MERGE fix negative has many through when no record in join table

### DIFF
--- a/app/models/hammerstone/refine/conditions/uses_attributes.rb
+++ b/app/models/hammerstone/refine/conditions/uses_attributes.rb
@@ -101,7 +101,7 @@ module Hammerstone::Refine::Conditions
       # Ex: A country has many posts through hmtt_users.
       # Use AR to properly join the relation to the base query provided
       # Convert to AREL to use with nodes 
-      subquery_path = query.model.select(key_1(instance)).joins(relation.to_sym).arel
+      subquery_path = query.model.select(key_1(instance)).left_joins(relation.to_sym).arel
       relation_table_being_queried = instance.klass.arel_table
 
       relation_class = instance.klass


### PR DESCRIPTION
Needs a test for the following case: 
- Has many through negative (example: contacts do not have a tag) when there is no record in the join table. 