### PR TITLE
Remove dependence on workspace record

### DIFF
--- a/app/controllers/hammerstone/refine/stored_filters_controller.rb
+++ b/app/controllers/hammerstone/refine/stored_filters_controller.rb
@@ -9,9 +9,9 @@ module Hammerstone::Refine
       return redirect_to hammerstone_refine_stored_filter_path(id: params[:id]) unless params[:id].nil?
       @stored_filter = StoredFilter.find_by(id: params[:selected_filter_id])
       # Get all stored filters for this workspace to select from.
-      # TODO offer option for additional scoping?
+      # TODO how to set stored filters??
       # TODO if load filters is clicked but no filter is selected the widget is in an awkward state.
-      @stored_filters = StoredFilter.where(workspace_id: current_workspace.id)
+      @stored_filters = StoredFilter.all
       if @stored_filter
         @back_link = hammerstone_refine_stored_filter_path(return_params.except(:selected_filter_id))
       else
@@ -43,7 +43,7 @@ module Hammerstone::Refine
         @stored_filter = saved_stored_filter
         @stored_filter.update(name: params[:name], state: refine_filter.state)
       else
-        @stored_filter = StoredFilter.new(name: params[:name], state: refine_filter.state, workspace_id: current_workspace.id, filter_type: refine_filter.type)
+        @stored_filter = StoredFilter.new(name: params[:name], state: refine_filter.state, filter_type: refine_filter.type)
       end
       
       if @stored_filter.save
@@ -54,7 +54,7 @@ module Hammerstone::Refine
     end
 
     def new
-      @stored_filter = StoredFilter.new(name: "", state: refine_filter.state, workspace_id: current_workspace.id, filter_type: refine_filter.type)
+      @stored_filter = StoredFilter.new(name: "", state: refine_filter.state, filter_type: refine_filter.type)
       @stable_id = stable_id
       @back_link = editor_hammerstone_refine_stored_filters_path(return_params)
     end
@@ -63,12 +63,13 @@ module Hammerstone::Refine
       @stored_filter = StoredFilter.find_by(id: params[:id])
       # Show the refine filter for the stored filter id unless a stable id param is given
       @refine_filter = refine_filter || @stored_filter&.refine_filter
+      @form = Hammerstone::Refine::FilterForms::Form.new(@refine_filter)
       @save_button_active = !!stable_id
       @return_params = return_params.except(:id)
     end
 
     def create
-      @stored_filter = StoredFilter.new(name: params[:name], state: refine_filter.state, workspace_id: current_workspace.id, filter_type: refine_filter.type)
+      @stored_filter = StoredFilter.new(name: params[:name], state: refine_filter.state, filter_type: refine_filter.type)
       @stable_id = stable_id
       @back_link = editor_hammerstone_refine_stored_filters_path(return_params)
 

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -9,4 +9,6 @@ en:
       choose_filter: Load filter 
       filter_name: Filter Name
       filter: Filter
+      back: Back
+      save: Save
 


### PR DESCRIPTION
- Remove the dependence on `workspace`, a CF specific issue. Goes with https://github.com/leenyburger/bullet_train_test_refine_npm_package/pull/20

Problem: 
CF and other implementors will have to override this controller if they want custom attributes on their stored filters - any other way around this?

https://www.loom.com/share/8c59012542d445d2ab188150796c2177
