### PR TITLE
WIP: Allow for custom validation messages

### DIFF
--- a/app/models/hammerstone/refine/conditions/clause.rb
+++ b/app/models/hammerstone/refine/conditions/clause.rb
@@ -8,19 +8,18 @@ module Hammerstone::Refine::Conditions
     def initialize(id = nil, display = nil)
       @id = id
       @display = display || id.humanize(keep_id_suffix: true).titleize
-      @rules = {}
-      @messages
+      @rules = []
     end
 
     def with_rules(user_defined_hash)
-      @rules.merge!(user_defined_hash)
+      @rules << (user_defined_hash)
       self
     end
 
     def requires_inputs(fields)
       # Coerce field to an array
       [*fields].each do |field|
-        @rules.merge!({"#{field}": "required"})
+        @rules << ({field: "#{field}", rule: "required", message_key: Hammerstone::Refine::Conditions::Errors::ValidationErrors::FIELD_REQUIRED})
       end
       self
     end

--- a/app/models/hammerstone/refine/conditions/errors/validation_errors.rb
+++ b/app/models/hammerstone/refine/conditions/errors/validation_errors.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+module Hammerstone::Refine::Conditions::Errors
+  class ValidationErrors
+    FIELD_REQUIRED = "field_required"
+    CLAUSE_REQUIRED = "clause_required"
+  end
+end

--- a/app/models/hammerstone/refine/conditions/has_clauses.rb
+++ b/app/models/hammerstone/refine/conditions/has_clauses.rb
@@ -9,7 +9,7 @@ module Hammerstone::Refine::Conditions
 
     def boot_has_clauses
       @show_clauses = {}
-      add_rules({ clause: "required" })
+      add_rules({ field: "clause", rule: "required", message_key: Hammerstone::Refine::Conditions::Errors::ValidationErrors::CLAUSE_REQUIRED })
       with_meta({ clauses: get_clauses })
       add_ensurance(ensure_clauses)
       before_validate(before_clause_validation)


### PR DESCRIPTION
This PR allows the end user to override the validation messages. This is done using constants. 
Implementing details: 
` NumericCondition.new("numeric_condition").remap_validation_messages({ Hammerstone::Refine::Conditions::Errors::ValidationErrors::FIELD_REQUIRED => "Please enter a value for the number"}),`

Works for single conditions, does not work for "betweens" yet. 
The betweens is an *existing* issue which is because of the way the errors are being added to the criterion object and then shown in the view. `Hammerstone::Refine::Filters::Criterion`
It looks like what is happening is that the correct number (only 2) errors are being added to the criterion object. But when we get to the view, _each_ field lists both errors. This makes sense because the error partial is rendered for each field with all criterion errors. We'll need a way to distinguish which error goes to which field. 

<img width="936" alt="Screen Shot 2023-04-07 at 2 10 41 PM" src="https://user-images.githubusercontent.com/9285725/230679516-8a2a0395-e723-4cc4-89f7-804e3f4d38b0.png">
