### PR TITLE
Add get_query! to raise an error on invalid filter

### DIFF
--- a/app/models/hammerstone/refine/filter.rb
+++ b/app/models/hammerstone/refine/filter.rb
@@ -75,6 +75,12 @@ module Hammerstone::Refine
       end
     end
 
+    def get_query!
+      result = get_query
+      raise Hammerstone::Refine::InvalidFilterError.new(filter: self) unless errors.none?
+      result
+    end
+
     def add_nodes_to_query(subquery:, nodes:, query_method:)
       # Apply existing nodes to existing subquery
       if subquery.present? && nodes.present?

--- a/app/models/hammerstone/refine/invalid_filter_error.rb
+++ b/app/models/hammerstone/refine/invalid_filter_error.rb
@@ -1,0 +1,8 @@
+class Hammerstone::Refine::InvalidFilterError < StandardError
+  attr_reader :filter
+
+  def initialize(msg="Filter is invalid", filter: nil)
+    @msg = msg
+    filter = filter
+  end
+end

--- a/test/hammerstone/models/filters/basic_filter_test.rb
+++ b/test/hammerstone/models/filters/basic_filter_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "support/hammerstone/test_double_filter"
+require "hammerstone/refine/invalid_filter_error"
 
 describe Hammerstone::Refine::Filter do
   include FilterTestHelper
@@ -26,6 +27,14 @@ describe Hammerstone::Refine::Filter do
       query.conditions = [Hammerstone::Refine::Conditions::TextCondition.new("text_field_value")]
       query.get_query
       assert query.errors.added? :filter, "The condition ID fake was not found"
+    end
+
+    it "get_query! raises exception" do
+      filter = TestDoubleFilter.new(bad_id)
+      filter.conditions = [Hammerstone::Refine::Conditions::TextCondition.new("text_field_value")]
+      assert_raises(Hammerstone::Refine::InvalidFilterError) do
+        filter.get_query!
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds `Hammerstone::Refine::Filter#get_query!` that works like get_query only it raises an error if the filter has validation errors that would result in a bad scope being returned.