### PR TITLE
adding edge case support for gte as well

### DIFF
--- a/app/models/hammerstone/refine/conditions/date_condition.rb
+++ b/app/models/hammerstone/refine/conditions/date_condition.rb
@@ -290,7 +290,12 @@ module Hammerstone::Refine::Conditions
       when CLAUSE_GREATER_THAN
         apply_clause_greater_than(comparison_time(date1), table)
       when CLAUSE_GREATER_THAN_OR_EQUAL
-        apply_clause_greater_than_or_equal(comparison_time(date1), table)
+        if Refine::Rails.configuration.date_gte_uses_bod
+          datetime = start_of_day(date1)
+        else
+          datetime = comparison_time(date1)
+        end
+        apply_clause_greater_than_or_equal(datetime, table)
       when CLAUSE_LESS_THAN_OR_EQUAL
         if Refine::Rails.configuration.date_lte_uses_eod
           datetime = end_of_day(date1)

--- a/lib/refine/rails.rb
+++ b/lib/refine/rails.rb
@@ -10,6 +10,7 @@ module Refine
       :custom_stored_filter_attributes,
       :stabilizer_classes,
       :date_lte_uses_eod,
+      :date_gte_uses_bod,
       :option_condition_ordering,
       keyword_init: true
     ); end
@@ -22,6 +23,7 @@ module Refine
         url: Hammerstone::Refine::Stabilizers::UrlEncodedStabilizer
       },
       date_lte_uses_eod: false,
+      date_gte_uses_bod: false,
       option_condition_ordering: ->(options) { options }
     )
 

--- a/test/hammerstone/models/conditions/date_with_time_condition_test.rb
+++ b/test/hammerstone/models/conditions/date_with_time_condition_test.rb
@@ -202,6 +202,26 @@ module Hammerstone::Refine::Conditions
         end
       end
 
+      describe 'date_gte_uses_bod set' do
+        before do
+          @date_gte_uses_bod_was = Refine::Rails.configuration.date_gte_uses_bod
+          Refine::Rails.configuration.date_gte_uses_bod = true
+        end
+
+        after do
+          Refine::Rails.configuration.date_gte_uses_bod = @date_gte_uses_bod_was
+        end
+
+        it 'uses end of day for clause greater than or equal' do
+         condition = DateWithTimeCondition.new("date_test")
+         data = {clause: DateCondition::CLAUSE_GREATER_THAN_OR_EQUAL, date1: "2019-05-15"}
+         expected_sql = <<~SQL.squish
+           SELECT "t".* FROM "t" WHERE ("t"."date_test" >= '2019-05-15 00:00:00')
+         SQL
+         assert_equal convert(expected_sql), apply_condition_on_test_filter(condition, data).to_sql 
+        end
+      end
+
       describe "Human readable text representation" do
         it "correctly outputs human readable text for 'is set' clause" do
           condition = DateWithTimeCondition.new("date_test")


### PR DESCRIPTION
This is very similar to https://github.com/hammerstonedev/refine-rails/pull/116, but for the opposite edge case.
* Adds a new config option date_gte_uses_bod,