### PR TITLE
fixing an issue where a proc could be in the options conditions

### DIFF
--- a/app/views/hammerstone/refine_blueprints/clauses/_option_condition.html.erb
+++ b/app/views/hammerstone/refine_blueprints/clauses/_option_condition.html.erb
@@ -16,7 +16,7 @@
         name="values"
         data-input-id='<%= input_id if input_id%>'
       >
-      <% condition.options.each do |option| %>
+      <% condition.meta[:options].each do |option| %>
         <option
           value="<%= option[:id] %>"
           <% if selected.find { |id|  id == option[:id] } %>selected<% end %>


### PR DESCRIPTION
Based on an issue from our previous work on allowing option condition options to be sorted, there was an edge case where the code iterating over the options would choke on it if it was rendering a proc instead of a flat array. This goes back to an earlier code version using the `meta` object instead of the options directly.

Note - I do not know the context of why this was changed from the meta to `condition.options` directly so I might be missing something here.