### PR TITLE
Handle invalid stored filters

### DIFF
--- a/app/controllers/hammerstone/refine/stored_filters_controller.rb
+++ b/app/controllers/hammerstone/refine/stored_filters_controller.rb
@@ -14,6 +14,10 @@ module Hammerstone::Refine
       @refine_filter_builder.stored_filter_id = @stored_filter.id
       @refine_filter = @stored_filter.refine_filter
       @refine_filter_query = Hammerstone::Refine::Filters::Query.new(@refine_filter)
+      unless @refine_filter.valid_query?
+        redirect_to hammerstone_refine_stored_filters_path(@refine_filter_builder.to_params),
+          alert: "Sorry, that filter is not valid"
+      end
     end
 
     def new

--- a/app/models/hammerstone/refine/filter.rb
+++ b/app/models/hammerstone/refine/filter.rb
@@ -79,6 +79,11 @@ module Hammerstone::Refine
       initial_query.model.arel_table
     end
 
+    def valid_query?
+      get_query
+      errors.none?
+    end
+
     def get_query
       raise "Initial query must exist" if initial_query.nil?
       if blueprint.present?

--- a/app/views/hammerstone/refine/stored_filters/index.html.erb
+++ b/app/views/hammerstone/refine/stored_filters/index.html.erb
@@ -1,4 +1,10 @@
 <%= turbo_frame_tag "stored_filters" do %>
+  <% if flash.alert %>
+    <p class="refine-criterion-error">
+      <%= flash.alert %>
+    </p>
+  <% end %>
+
   <%= content_tag :div, class: "refine-stored-filter-search-container" do %>
     <%= form_with(
         model: @refine_filter_builder,


### PR DESCRIPTION
This PR implements error handling logic for stored filters.  If the user attempts to load a stored filter that is not valid and would cause an error it now shows some error text instead.