### PR TITLE
Validate stored_filter using filter model

### DIFF
--- a/app/models/hammerstone/refine/filter.rb
+++ b/app/models/hammerstone/refine/filter.rb
@@ -65,6 +65,11 @@ module Hammerstone::Refine
       true
     end
 
+    # override this in filter classes
+    def model
+      ActiveRecord::Base
+    end
+
     # If the initial condition has not been set in the filter, validation for relationships will error.
     # The BT implementation builds the filter *then* sets the initial condition
     # This pulls a "smart" default from the filter arel table - Arel::Table provides the table name, can extract the model then call "all"

--- a/app/models/hammerstone/refine/stored_filter.rb
+++ b/app/models/hammerstone/refine/stored_filter.rb
@@ -3,8 +3,8 @@ module Hammerstone::Refine
     validates_presence_of :state
     self.table_name = "hammerstone_refine_stored_filters"
 
-    def refine_filter
-      Refine::Rails.configuration.stabilizer_classes[:db].new.from_stable_id(id: id)
+    def refine_filter(initial_query: nil)
+      Refine::Rails.configuration.stabilizer_classes[:db].new.from_stable_id(id: id, initial_query: initial_query)
     end
 
     def blueprint


### PR DESCRIPTION
This PR updates the logic for validating stored filters when they are loaded.  In order to validate a filter, we presently need to generate the filter scope, even though if that scope is never evaluated.  This PR has filters define a `#model` method which is be used to generate a throwaway base scope which is used to validate the filter.