### PR TITLE
Handle option conditions with no options

### DIFF
--- a/app/javascript/controllers/refine/state-controller.js
+++ b/app/javascript/controllers/refine/state-controller.js
@@ -76,7 +76,6 @@ export default class extends Controller {
 
 
   connect() {
-    console.log("This is STILL my state controller!")
     // for select2 jquery events and datepicker
     this.element.refineStateController = this
     this.changeDelegate = delegate('change', ['event', 'picker'])


### PR DESCRIPTION
This PR fixes an error that was occurring where the form would fail to update if an option condition was selected and no options are available.  See https://linear.app/clickfunnels/issue/QUE-106/issue-with-filtering-on-objects-that-dont-exist