### PR TITLE
[INT2-6] Add missing changes for internationalisation

### DIFF
--- a/app/javascript/controllers/refine/date-controller.js
+++ b/app/javascript/controllers/refine/date-controller.js
@@ -4,6 +4,7 @@ import 'moment/locale/es'
 import flatpickr from "flatpickr"
 require("flatpickr/dist/flatpickr.css")
 require('flatpickr/dist/l10n/es')
+require('flatpickr/dist/l10n/pt')
 
 /*
   Stimulus controller for initializing the datepicker.
@@ -21,6 +22,8 @@ export default class extends Controller {
 
   static values = {
     locale: { type: String, default: 'en' },
+    dateFormat: { type: String, default:  'MM/DD/YYYY' },
+    datetimeFormat: { type: String, default:  'MM/DD/YYYY h:mm A' },
   }
 
   connect() {
@@ -58,7 +61,7 @@ export default class extends Controller {
         return momentDate.format(format)
       },
       onChange: (selectedDates, dateStr, instance) => {
-        const format = this.includeTimeValue ? 'L LT' : 'L'
+        const format = this.includeTimeValue ? this.datetimeFormatValue : this.dateFormatValue
         // display format
         this.fieldTarget.value = instance.formatDate(selectedDates[0], format)
         // internal format saved in db
@@ -69,7 +72,7 @@ export default class extends Controller {
         () => {
           const momentDate = moment(this.hiddenFieldTarget.value)
           if (momentDate.isValid()) {
-            const format = this.includeTimeValue ? 'L LT' : 'L'
+            const format = this.includeTimeValue ? this.datetimeFormatValue : this.dateFormatValue
             this.fieldTarget.value = momentDate.format(format)
           }
         },

--- a/app/views/hammerstone/refine/inline/inputs/_date_picker.html.erb
+++ b/app/views/hammerstone/refine/inline/inputs/_date_picker.html.erb
@@ -2,16 +2,18 @@
   data-controller="refine--date" 
   class="refine-date-picker-container"
   data-refine--date-locale-value="<%= I18n.locale %>"
+  data-refine--date-date-format-value="<%=  I18n.t("hammerstone.date.formats.moment") %>"
+  data-refine--date-datetime-format-value="<%= I18n.t("hammerstone.time.formats.moment") %>"
 >
   <%= input_fields.label attribute, label %>
   <input
     class="refine-date-picker-input"
     type="text"
-    value="<%= value&.to_date&.strftime('%m/%d/%y') %>"
+    value="<%= value&.to_date && I18n.l(value&.to_date, format: I18n.t("hammerstone.date.formats.ruby"))  %>"
     data-refine--date-target="field"
   />
   <%= input_fields.hidden_field attribute,
-    value: value&.to_date&.strftime('%m/%d/%y'),
+    value: value&.to_date&.strftime('%Y-%m-%d'),
     data: { refine__date_target: "hiddenField" }
   %>
 </div>

--- a/app/views/hammerstone/refine_blueprints/clauses/_date_picker.html.erb
+++ b/app/views/hammerstone/refine_blueprints/clauses/_date_picker.html.erb
@@ -2,18 +2,20 @@
   data-controller="refine--date"
   class="refine-date-picker-container"
   data-refine--date-locale-value="<%= I18n.locale %>"
+  data-refine--date-date-format-value="<%=  I18n.t("hammerstone.date.formats.moment") %>"
+  data-refine--date-datetime-format-value="<%= I18n.t("hammerstone.time.formats.moment") %>"
 >
   <label for="<%= condition_id %>" class="sr-only"><%= label %></label>
   <input
     class="refine--date-picker-input"
     type="text"
-    value="<%= date&.to_date&.strftime('%m/%d/%y') %>"
+    value="<%= date&.to_date && I18n.l(date&.to_date, format: I18n.t("hammerstone.date.formats.ruby")) %>"
     data-refine--date-target="field"
   />
   <input
     type="hidden"
     name="<%= condition_id %>"
-    value="<%= date&.to_date&.strftime('%y-%m-%d') %>"
+    value="<%= date&.to_date&.strftime('%Y-%m-%d') %>"
     data-refine--date-target="hiddenField"
     data-input-key="<%= input_key %>"
     data-input-id="<%= defined?(input_id) && input_id %>"

--- a/config/locales/en/refine.en.yml
+++ b/config/locales/en/refine.en.yml
@@ -1,5 +1,13 @@
 en:
   hammerstone:
+    date:
+      formats:
+        ruby: "%m/%d/%y"
+        moment: "MM/DD/YYYY"
+    time:
+      formats:
+        ruby: "%m/%d/%Y %l:%M %p"
+        moment: "MM/DD/YYYY h:mm A"
     stored_filters:
       select_saved_filter: "Select a saved filter"
     inline:


### PR DESCRIPTION
These missing changes are needed to avoid monkey patching the views and date_controller.
I also added the capability to customize the format as the date and datetime format is not always the same depending on the country.