### PR TITLE
Add exception when invalid condition is loaded

### DIFF
--- a/app/models/hammerstone/refine/filters/criterion.rb
+++ b/app/models/hammerstone/refine/filters/criterion.rb
@@ -80,6 +80,8 @@ class Hammerstone::Refine::Filters::Criterion
     if @condition
       @condition.set_filter(filter)
       filter.translate_display(@condition)
+    else
+      raise Hammerstone::Refine::InvalidFilterError
     end
   end
 end

--- a/test/hammerstone/models/filters/basic_filter_test.rb
+++ b/test/hammerstone/models/filters/basic_filter_test.rb
@@ -36,6 +36,14 @@ describe Hammerstone::Refine::Filter do
         filter.get_query!
       end
     end
+
+    it "missing condition raises exception" do
+      filter = create_filter(invalid_condition_blueprint)
+
+      assert_raises Hammerstone::Refine::InvalidFilterError do
+        Hammerstone::Refine::Filters::Query.new(filter)
+      end
+    end
   end
 
   describe "basic filters with ands" do
@@ -330,6 +338,18 @@ describe Hammerstone::Refine::Filter do
       input: {
         clause: "eq",
         value: "aaron"
+      }
+    }]
+  end
+
+  def invalid_condition_blueprint
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "invalid_condition",
+      input: {
+        clause: "eq",
+        value: "invalid"
       }
     }]
   end


### PR DESCRIPTION
This adds an `Hammerstone::Refine::InvalidFilterError` when a filter query is loaded and a condition is invalid or doesn't exist.

This is to solve an issue where if a custom attribute is deleted and a Filter containing that attribute is loaded `#meta` errors out since the condition itself is nil. This makes things easier to catch in the implementors and is apart of https://linear.app/clickfunnels/issue/FUN-506/fb-or-removing-a-contact-attribute-that-is-connected-to-a-funnel work to ensure we handle these errors appropriately. 

This should be a low impact change, given that it will throw a `NoMethodError` error if `@condition` is nil. So hopefully this is ok.