### PR TITLE
Human readable for CLAUSE_BETWEEN when dates are the same

### DIFF
--- a/app/models/refine/conditions/date_condition.rb
+++ b/app/models/refine/conditions/date_condition.rb
@@ -121,7 +121,12 @@ module Refine::Conditions
         formatted_date1 = I18n.l(input[:date1].to_date, format: :dmy)
         formatted_date2 = I18n.l(input[:date2].to_date, format: :dmy)
         and_i18n = I18n.t("#{I18N_PREFIX}and")
-        "#{display} #{current_clause.display} #{formatted_date1} #{and_i18n} #{formatted_date2}#{timezone_abbr}"
+
+        if formatted_date1 == formatted_date2
+          "#{display} #{get_clause_by_id(CLAUSE_EQUALS).display} #{formatted_date1}#{timezone_abbr}"
+        else
+          "#{display} #{current_clause.display} #{formatted_date1} #{and_i18n} #{formatted_date2}#{timezone_abbr}"
+        end
       when *[CLAUSE_GREATER_THAN, CLAUSE_LESS_THAN, CLAUSE_EXACTLY]
         days_i18n = I18n.t("#{I18N_PREFIX}days")
         ago_i18n = I18n.t("#{I18N_PREFIX}ago")
@@ -146,7 +151,12 @@ module Refine::Conditions
         formatted_date1 = I18n.l(input[:date1].to_date, format: :dmy)
         formatted_date2 = I18n.l(input[:date2].to_date, format: :dmy)
         and_i18n = I18n.t("#{I18N_PREFIX}and")
-        "#{formatted_date1} #{and_i18n} #{formatted_date2}#{timezone_abbr}"
+        
+        if formatted_date1 == formatted_date2
+          "#{formatted_date1}#{timezone_abbr}"
+        else
+          "#{formatted_date1} #{and_i18n} #{formatted_date2}#{timezone_abbr}"
+        end
       when *[CLAUSE_GREATER_THAN, CLAUSE_LESS_THAN, CLAUSE_EXACTLY]
         days_i18n = I18n.t("#{I18N_PREFIX}and")
         ago_i18n = I18n.t("#{I18N_PREFIX}days")

--- a/test/refine/models/conditions/date_condition_test.rb
+++ b/test/refine/models/conditions/date_condition_test.rb
@@ -167,6 +167,24 @@ module Refine::Conditions
 
           assert_equal "Date To Test equals 05/15/19", condition.human_readable(data)
         end
+
+        it "correctly outputs human readable text for 'between' clause using remap" do
+          data = {clause: DateCondition::CLAUSE_BETWEEN, date1: "2019-05-15", date2: "2020-05-15"}
+          condition = DateCondition.new("date_to_test").remap_clause_displays({eq: "between"})
+          filter = apply_condition_and_return_filter(condition, data)
+          filter.translate_display(condition)
+
+          assert_equal "Date To Test is between 05/15/19 and 05/15/20", condition.human_readable(data)
+        end
+
+        it "correctly outputs human readable text for 'between' when dates are the same clause using remap" do
+          data = {clause: DateCondition::CLAUSE_BETWEEN, date1: "2019-05-15", date2: "2019-05-15"}
+          condition = DateCondition.new("date_to_test").remap_clause_displays({eq: "equals"})
+          filter = apply_condition_and_return_filter(condition, data)
+          filter.translate_display(condition)
+
+          assert_equal "Date To Test equals 05/15/19", condition.human_readable(data)
+        end
       end
     end
   end


### PR DESCRIPTION
In a bug report, its possible to select the same date in a DateCondition::CLAUSE_BETWEEN.
Instead of simply not allowing the same date, the code already treats it the same way as a `CLAUSE_EQUAL` in the SQL query. Therefore, this will also treat the human_readable output the same way, where in the case that the two dates are equal, the string is output the same as the CLAUSE_EQUAL output
