### PR TITLE
adding validation to prevent date1 from being greater than date2

### DIFF
--- a/app/models/refine/conditions/date_condition.rb
+++ b/app/models/refine/conditions/date_condition.rb
@@ -3,7 +3,7 @@ module Refine::Conditions
     include ActiveModel::Validations
     include HasClauses
 
-    validate :date1_must_be_real, :date2_must_be_real
+    validate :date1_must_be_real, :date2_must_be_real, :date1_must_be_less_than_date2
 
     cattr_accessor :default_user_timezone, default: "UTC", instance_accessor: false
     cattr_accessor :default_database_timezone, default: "UTC", instance_accessor: false
@@ -48,6 +48,16 @@ module Refine::Conditions
       rescue ArgumentError
         errors.add(:base, I18n.t("#{I18N_PREFIX}date2_error"))
         false
+      end
+    end
+
+    def date1_must_be_less_than_date2
+      return true unless date1 && date2
+      if Date.strptime(date1, "%Y-%m-%d") > Date.strptime(date2, "%Y-%m-%d")
+        errors.add(:base, I18n.t("#{I18N_PREFIX}date1_greater_date2_error"))
+        false
+      else
+        true
       end
     end
 

--- a/config/locales/en/refine.en.yml
+++ b/config/locales/en/refine.en.yml
@@ -108,6 +108,7 @@ en:
       date_condition:
         date1_error: date1 is not a real date
         date2_error: date2 is not a real date
+        date1_greater_date2_error: Start date must be an earlier date than end date
         timezone_error: "%{zone} timezone does not exist in ActiveSupport::TimeZone"
         and: and
         days: days

--- a/test/refine/models/conditions/date_condition_test.rb
+++ b/test/refine/models/conditions/date_condition_test.rb
@@ -23,6 +23,18 @@ module Refine::Conditions
         filter = apply_condition_and_return_filter(condition, data)
         assert_equal(["date1 is not a real date"], filter.errors.full_messages)
       end
+
+      it "throws an error for a between clause when date 1 is later than date 2" do
+        data = {clause: DateCondition::CLAUSE_BETWEEN, date1: "2019-06-15",  date2: "2019-05-15"}
+        filter = apply_condition_and_return_filter(condition, data)
+        assert_equal(["Start date must be an earlier date than end date"], filter.errors.full_messages)
+      end
+
+      it "throws an error for a not between clause when date 1 is later than date 2" do
+        data = {clause: DateCondition::CLAUSE_NOT_BETWEEN, date1: "2019-06-15",  date2: "2019-05-15"}
+        filter = apply_condition_and_return_filter(condition, data)
+        assert_equal(["Start date must be an earlier date than end date"], filter.errors.full_messages)
+      end
     end
 
     describe "clause application" do


### PR DESCRIPTION
This addresses a usability feedback where it was possible for a user to do a between filter where the start date was greater than the end date. 