### PR TITLE
Fixing issue where set and not set were rendering a date selector

### DIFF
--- a/app/views/refine/inline/inputs/_date_condition.html.erb
+++ b/app/views/refine/inline/inputs/_date_condition.html.erb
@@ -2,6 +2,8 @@
   <%= render "refine/inline/inputs/date_condition_days", input_fields: input_fields, criterion: criterion, form_id: form_id %>
 <% elsif input_fields.object.clause.in? ["btwn", "nbtwn"] %>
   <%= render "refine/inline/inputs/date_condition_range", input_fields: input_fields, criterion: criterion, form_id: form_id %>
+<% elsif input_fields.object.clause.in? ['st', 'nst'] %>
+  <!-- render nothing -->
 <% else %>
   <%= render "refine/inline/inputs/date_condition_single", input_fields: input_fields, criterion: criterion, form_id: form_id %>
 <% end %>

--- a/test/refine/models/conditions/filter_condition_test.rb
+++ b/test/refine/models/conditions/filter_condition_test.rb
@@ -26,7 +26,6 @@ module Refine::Conditions
       ENV['NAMESPACE_REFINE_STABILIZERS'] = "1"
       Refine::StoredFilter.destroy_all
       Refine::StoredFilter.create(name: "A filter of an awesome product", state: filter_state, id: 2,filter_type: "ProductsFilter")
-      puts "filter condition test"
 
       data = {clause: FilterCondition::CLAUSE_IN, selected: ["2"]}
       expected_sql = <<~SQL.squish

--- a/test/refine/models/conditions/option_condition_test.rb
+++ b/test/refine/models/conditions/option_condition_test.rb
@@ -320,22 +320,23 @@ module Refine::Conditions
         assert_equal(["Selected option_7 is not configured in options list"], filter.errors.full_messages)
       end
 
-      it "only accepts options in the set of ids. Can be strings or integers" do
-        condition = OptionCondition.new("option_test")
-          .with_options(
-            [{
-              id: "1",
-              display: "Option 1"
-            }, {
-              id: 2,
-              display: "Option 2"
-            }]
-          )
+      # TODO uncomment this once we fix the issue with requiring optioncondition ids to be strings
+      # it "only accepts options in the set of ids. Can be strings or integers" do
+      #   condition = OptionCondition.new("option_test")
+      #     .with_options(
+      #       [{
+      #         id: "1",
+      #         display: "Option 1"
+      #       }, {
+      #         id: 2,
+      #         display: "Option 2"
+      #       }]
+      #     )
 
-        data = {clause: OptionCondition::CLAUSE_EQUALS, selected: [1]}
-        filter = apply_condition_and_return_filter(condition, data)
-        assert_equal([], filter.errors.full_messages)
-      end
+      #   data = {clause: OptionCondition::CLAUSE_EQUALS, selected: [1]}
+      #   filter = apply_condition_and_return_filter(condition, data)
+      #   assert_equal([], filter.errors.full_messages)
+      # end
     end
 
     describe "Human readable text representation" do

--- a/test/refine/models/conditions/option_condition_test.rb
+++ b/test/refine/models/conditions/option_condition_test.rb
@@ -319,6 +319,23 @@ module Refine::Conditions
         filter = apply_condition_and_return_filter(condition, data)
         assert_equal(["Selected option_7 is not configured in options list"], filter.errors.full_messages)
       end
+
+      it "only accepts options in the set of ids. Can be strings or integers" do
+        condition = OptionCondition.new("option_test")
+          .with_options(
+            [{
+              id: "1",
+              display: "Option 1"
+            }, {
+              id: 2,
+              display: "Option 2"
+            }]
+          )
+
+        data = {clause: OptionCondition::CLAUSE_EQUALS, selected: [1]}
+        filter = apply_condition_and_return_filter(condition, data)
+        assert_equal([], filter.errors.full_messages)
+      end
     end
 
     describe "Human readable text representation" do


### PR DESCRIPTION
fixing a bug where inline date condition was rendering the date selector even when it wasn't necessary.
Adds commented out test which will be addressed in a future PR