### PR TITLE
Ensure a clause is always selected in inline UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.9.9
+  * Inline UI - edge case cleanup for conditions with only st and nst clauses allowed
 ### 2.9.8
   * Inline UI styling cleanup
 ### 2.9.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.9.8)
+    refine-rails (2.9.9)
       rails (>= 6.0)
 
 GEM

--- a/app/views/refine/inline/criteria/_form_fields.html.erb
+++ b/app/views/refine/inline/criteria/_form_fields.html.erb
@@ -2,6 +2,7 @@
   condition = @criterion.condition
   date_refinement_condition = condition.has_date_refinement? && condition.get_date_refinement_condition
   count_refinement_condition = condition.has_count_refinement? && condition.get_count_refinement_condition
+  condition_clause = @criterion.input.clause || condition.approved_clauses.first.id
 
   last_clause_select = if count_refinement_condition
     :count
@@ -23,7 +24,7 @@
 
 
   <%# Input Value %>
-  <% unless ['st', 'nst'].include? @criterion.input.clause %>
+  <% unless ['st', 'nst'].include? condition_clause %>
     <%= render @criterion.input_partial, criterion: @criterion, form: form, input_fields: input_fields, form_id: form_id %>
     <% if last_clause_select == :criterion %>
       <div class="refine--separator"></div>
@@ -37,7 +38,7 @@
       @criterion.condition.approved_clauses,
       :id,
       :display,
-      {},
+      {selected: condition_clause},
       class: "refine--select refine--clause-select",
       data: {action: "change->refine--criterion-form#refresh"},
       form: form_id

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.9.8"
+    VERSION = "2.9.9"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",


### PR DESCRIPTION
ensure we use the first available clause to render the inline form if no input is provided