### PR TITLE
fixing issue with loading filters in turbo streams

### DIFF
--- a/app/javascript/controllers/refine/submit-form-controller.js
+++ b/app/javascript/controllers/refine/submit-form-controller.js
@@ -3,6 +3,6 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   submit(event) {
     event.preventDefault()
-    this.element.submit()
+    this.element.requestSubmit()
   }
 }

--- a/app/views/refine/inline/stored_filters/index.html.erb
+++ b/app/views/refine/inline/stored_filters/index.html.erb
@@ -12,7 +12,6 @@
           method: :post,
           class: "refine--stored-filter-search-form",
           data: {
-            turbo_frame: "_top",
             controller: "refine--submit-form"
           }) do |form| %>
         <!-- Saved filter selector -->


### PR DESCRIPTION
Fixes an issue where using a turbo stream format didn't get registered when loading a stored filter in the inline ui