### PR TITLE
Feature - Recommended Conditions & Category Ordering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in refine-rails.gemspec.
 gemspec
 
-gem "mysql2"
+gem "mysql2", "~> 0.5.6"
 
 gem "sprockets-rails"
 gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.9.14)
+    refine-rails (2.10.0)
       rails (>= 6.0)
 
 GEM
@@ -102,7 +102,7 @@ GEM
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
     mysql2 (0.5.6)
-    net-imap (0.4.13)
+    net-imap (0.4.14)
       date
       net-protocol
     net-pop (0.1.2)
@@ -186,7 +186,7 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.16)
+    zeitwerk (2.6.17)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
       minitest (~> 5.0)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
-    mysql2 (0.5.4)
+    mysql2 (0.5.6)
     net-imap (0.4.13)
       date
       net-protocol
@@ -195,7 +195,7 @@ DEPENDENCIES
   byebug
   minitest-around
   minitest-ci
-  mysql2
+  mysql2 (~> 0.5.6)
   refine-rails!
   sprockets-rails
   standard

--- a/app/models/refine/filter.rb
+++ b/app/models/refine/filter.rb
@@ -312,5 +312,9 @@ module Refine
     def criteria_limit_set?
       criteria_limit.to_i.positive?
     end
+
+    def has_category_ordering?
+      respond_to?(:category_order) && category_order.is_a?(Array) && category_order.any?
+    end
   end
 end

--- a/app/views/refine/blueprints/_condition_select.html.erb
+++ b/app/views/refine/blueprints/_condition_select.html.erb
@@ -5,7 +5,9 @@
     conditions.filter { |c| c[:meta][:category] == category}
   end
 
-  categories = conditions.map { |c| c[:meta][:category] }.uniq.compact
+  # If an ordering has been defined for categories, use that, otherwise use the order in which they appear in the sorted conditions
+  categories = (@refine_filter.has_category_ordering?) ? @refine_filter.category_order : conditions.map { |c| c[:meta][:category] }.uniq.compact
+
   recommended_conditions = conditions.select { |c| c[:meta][:recommended] }
 
   # Note that the stimulus controllers set default condition id for new conditions

--- a/app/views/refine/blueprints/_condition_select.html.erb
+++ b/app/views/refine/blueprints/_condition_select.html.erb
@@ -6,6 +6,7 @@
   end
 
   categories = conditions.map { |c| c[:meta][:category] }.uniq.compact
+  recommended_conditions = conditions.select { |c| c[:meta][:recommended] }
 
   # Note that the stimulus controllers set default condition id for new conditions
   # so this is only for rare cases where it gets unset
@@ -40,6 +41,19 @@
         ><%= condition_option[:display] %></option>
       <% end %>
     </optgroup>
+
+    <% if recommended_conditions&.any? %>
+      <optgroup class="divider" label="<%= t(".recommended") %>">
+        <% recommended_conditions.each do |condition_option| %>
+          <option
+            value="<%= condition_option[:id] %>"
+            <% if selected_condition_id == condition_option[:id] %>selected<% end %>
+            title="<%= condition_option[:display] %>"
+          ><%= condition_option[:display] %></option>
+        <% end %>
+      </optgroup>
+    <% end %>
+
     <% categories.each do |category| %>
       <optgroup class="divider" label="<%= category %>">
         <% conditions_for_category.call(category).each do |condition_option| %>

--- a/app/views/refine/inline/criteria/index.html.erb
+++ b/app/views/refine/inline/criteria/index.html.erb
@@ -2,7 +2,13 @@
   # a hash mapping Category => [array, of, conditions], sorted by category
   categorized_conditions = @conditions
     .group_by {|c| c.meta[:category].presence}
-    .sort_by {|(category, _conditions)| category.to_s.downcase }
+    .sort_by do |(category, _conditions)|
+      if @refine_filter.has_category_ordering?
+        @refine_filter.category_order.index(category) || Float::INFINITY
+      else
+        category.to_s.downcase
+      end
+    end
     .to_h
 
   recommended_conditions = @conditions
@@ -35,8 +41,6 @@
     <div class="refine--separator-m0"></div>
 
     <div class="refine--condition-list">
-      <% puts "UNCATEGORIZED " %>
-      <% puts uncategorized_conditions.inspect %>
       <% if uncategorized_conditions&.any? %>
         <% uncategorized_conditions.each do |condition| %>
           <%= link_to condition.display,

--- a/app/views/refine/inline/criteria/index.html.erb
+++ b/app/views/refine/inline/criteria/index.html.erb
@@ -5,6 +5,10 @@
     .sort_by {|(category, _conditions)| category.to_s.downcase }
     .to_h
 
+  recommended_conditions = @conditions
+    .select { |c| c.meta[:recommended] }
+    .sort_by {|recommended| recommended.to_s.downcase }
+
   # an array of uncategorized conditions
   uncategorized_conditions = categorized_conditions.delete(nil)
 %>
@@ -31,17 +35,36 @@
     <div class="refine--separator-m0"></div>
 
     <div class="refine--condition-list">
-      <% uncategorized_conditions.each do |condition| %>
-        <%= link_to condition.display,
-          new_refine_inline_criterion_url(@criterion.to_params.deep_merge(refine_inline_criterion: {condition_id: condition.id})),
-          class: "refine--condition-list-item",
-          data: {
-            controller: "refine--turbo-stream-link",
-            action: "refine--turbo-stream-link#visit",
-            refine__typeahead_list_target: "listItem",
-            list_item_value: condition.display
-          }
-        %>
+      <% puts "UNCATEGORIZED " %>
+      <% puts uncategorized_conditions.inspect %>
+      <% if uncategorized_conditions&.any? %>
+        <% uncategorized_conditions.each do |condition| %>
+          <%= link_to condition.display,
+            new_refine_inline_criterion_url(@criterion.to_params.deep_merge(refine_inline_criterion: {condition_id: condition.id})),
+            class: "refine--condition-list-item",
+            data: {
+              controller: "refine--turbo-stream-link",
+              action: "refine--turbo-stream-link#visit",
+              refine__typeahead_list_target: "listItem",
+              list_item_value: condition.display
+            }
+          %>
+          <% end %>
+      <% end %>
+
+      <% if recommended_conditions.any? %>
+        <b data-refine--typeahead-list-target="recommended"><%= t('.recommended') %></b>
+        <% recommended_conditions.each do |condition| %>
+          <%= link_to condition.display,
+            new_refine_inline_criterion_url(@criterion.to_params.deep_merge(refine_inline_criterion: {condition_id: condition.id})),
+            class: "refine--condition-list-item",
+            data: {
+              controller: "refine--turbo-stream-link",
+              action: "refine--turbo-stream-link#visit",
+              refine__typeahead_list_target: "listItem",
+            }
+          %>
+        <% end %>
       <% end %>
 
       <%  categorized_conditions.each do |(category, conditions)| %>

--- a/config/locales/en/refine.en.yml
+++ b/config/locales/en/refine.en.yml
@@ -66,6 +66,10 @@ en:
         days: "days"
         and: "and"
 
+    blueprints:
+      condition_select:
+        recommended: "Recommended"
+
     refine_blueprints:
       add_and:
         add_and: "AND"
@@ -184,5 +188,8 @@ en:
         filters:
           add_first_condition_button:
             filter: "Filter"
+          criteria:
+            index:
+              recommended: "Recommended"
           load_button:
             load_filter: "Load Filter"

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.9.14"
+    VERSION = "2.10.0"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.9.14",
+  "version": "2.10.0",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",


### PR DESCRIPTION
Adds the following features:
1. When defining conditions, you may include the `meta` attribute `recommended: true`, which will render a copy of that condition in a "Recommended" category at the top of the list of conditions. Best used for filters with 10 or more conditions to choose from.
2. Previously, when defining conditions, you had no real control over what order the categories would be in. They would render in the order in which the category appeared in the flat conditions list. This would be either in the exact order of the definition or if the user had implemented `option_condition_ordering` on the refine initializer it would be based on that order.

Minor version bump - 2.10.0