### PR TITLE
Icon support for conditions in Inline UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.11.0
+  * New Feature - Allow icons to be used in condition dropdowns and give configurable control over rendering of the condition item. Note - this only impacts the Inline UI
+### 2.10.1
+  * Fix - addressed an issue where if no uncategorized conditions existed, an empty optgroup would appear
 ### 2.10.0
   * New Feature - Recommended Conditions: allows prepending condition list with recommended conditions
   * New Feature - Allow a filter to specify the order of categories with `def category_order`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.10.1)
+    refine-rails (2.11.0)
       rails (>= 6.0)
 
 GEM

--- a/app/models/refine/conditions/condition.rb
+++ b/app/models/refine/conditions/condition.rb
@@ -10,6 +10,7 @@ module Refine::Conditions
     include HasMeta
     include UsesAttributes
     include HasRefinements
+    include HasIcon
 
     attr_reader :ensurances, :before_validations, :clause, :filter
     attr_accessor :display, :id, :is_refinement, :attribute

--- a/app/models/refine/conditions/has_icon.rb
+++ b/app/models/refine/conditions/has_icon.rb
@@ -1,0 +1,24 @@
+module Refine::Conditions::HasIcon
+  def icon_class
+    @icon_class ||= nil
+  end
+
+  def icon_template
+    @icon_template ||= {}
+  end
+
+  def with_icon_class(icon_class)
+    @icon_class = icon_class
+    self
+  end
+
+  def with_icon_template(template_path:, locals: {})
+    @icon_template = { template_path: template_path, locals: locals }
+    self
+  end
+
+  def has_icon?
+    icon_class.present? || !icon_template.empty?
+  end
+
+end

--- a/app/views/refine/blueprints/_condition_select.html.erb
+++ b/app/views/refine/blueprints/_condition_select.html.erb
@@ -66,7 +66,7 @@
             <% if selected_condition_id == condition_option[:id] %>selected<% end %>
             title="<%= condition_option[:display] %>"
           >
-          <%= condition_option[:display] %>
+            <%= condition_option[:display] %>
           </option>
         <% end %>
       </optgroup>

--- a/app/views/refine/blueprints/_condition_select.html.erb
+++ b/app/views/refine/blueprints/_condition_select.html.erb
@@ -61,11 +61,21 @@
     <% categories.each do |category| %>
       <optgroup class="divider" label="<%= category %>">
         <% conditions_for_category.call(category).each do |condition_option| %>
+          <%= puts condition_option.inspect %>
           <option
             value="<%= condition_option[:id] %>"
             <% if selected_condition_id == condition_option[:id] %>selected<% end %>
             title="<%= condition_option[:display] %>"
-          ><%= condition_option[:display] %></option>
+          >
+            <% if condition_option[:icon_class] || condition_option[:icon_template] %>
+              <% if condition_option[:icon_class] %>
+                <i class="<%= condition_option[:icon_class] %>"></i>
+              <% else %>
+                TODO: Render template here
+              <% end %>
+            <% end %>
+            <%= condition_option[:display] %>
+          </option>
         <% end %>
       </optgroup>
     <% end %>

--- a/app/views/refine/blueprints/_condition_select.html.erb
+++ b/app/views/refine/blueprints/_condition_select.html.erb
@@ -61,20 +61,12 @@
     <% categories.each do |category| %>
       <optgroup class="divider" label="<%= category %>">
         <% conditions_for_category.call(category).each do |condition_option| %>
-          <%= puts condition_option.inspect %>
           <option
             value="<%= condition_option[:id] %>"
             <% if selected_condition_id == condition_option[:id] %>selected<% end %>
             title="<%= condition_option[:display] %>"
           >
-            <% if condition_option[:icon_class] || condition_option[:icon_template] %>
-              <% if condition_option[:icon_class] %>
-                <i class="<%= condition_option[:icon_class] %>"></i>
-              <% else %>
-                TODO: Render template here
-              <% end %>
-            <% end %>
-            <%= condition_option[:display] %>
+          <%= condition_option[:display] %>
           </option>
         <% end %>
       </optgroup>

--- a/app/views/refine/inline/criteria/_condition_list_item.html.erb
+++ b/app/views/refine/inline/criteria/_condition_list_item.html.erb
@@ -1,0 +1,27 @@
+<% 
+  category ||= nil
+
+  data = {
+    controller: "refine--turbo-stream-link",
+    action: "refine--turbo-stream-link#visit",
+    refine__typeahead_list_target: "listItem",
+    list_item_value: condition.display,
+  } 
+  if category && category.present?
+    data[:category] = category
+  end
+%>
+<%= link_to(
+  new_refine_inline_criterion_url(@criterion.to_params.deep_merge(refine_inline_criterion: {condition_id: condition.id})),
+  {
+    class: "refine--condition-list-item",
+  }.merge(data: data)) do %>
+  <% if condition.has_icon? %>
+    <% if condition.icon_class.present? %>
+      <i class="<%= condition.icon_class %>"></i>
+    <% else %>
+      <%= render partial: condition.icon_template[:template_path], locals: condition.icon_template[:locals] %>
+    <% end %>
+  <% end %>
+  <%= condition.display %>
+<% end %>

--- a/app/views/refine/inline/criteria/index.html.erb
+++ b/app/views/refine/inline/criteria/index.html.erb
@@ -43,49 +43,21 @@
     <div class="refine--condition-list">
       <% if uncategorized_conditions&.any? %>
         <% uncategorized_conditions.each do |condition| %>
-          <%= link_to condition.display,
-            new_refine_inline_criterion_url(@criterion.to_params.deep_merge(refine_inline_criterion: {condition_id: condition.id})),
-            class: "refine--condition-list-item",
-            data: {
-              controller: "refine--turbo-stream-link",
-              action: "refine--turbo-stream-link#visit",
-              refine__typeahead_list_target: "listItem",
-              list_item_value: condition.display
-            }
-          %>
-          <% end %>
+          <%= render partial: "condition_list_item", locals: {condition: condition } %> 
+        <% end %>
       <% end %>
 
       <% if recommended_conditions.any? %>
         <b data-refine--typeahead-list-target="recommended"><%= t('.recommended') %></b>
         <% recommended_conditions.each do |condition| %>
-          <%= link_to condition.display,
-            new_refine_inline_criterion_url(@criterion.to_params.deep_merge(refine_inline_criterion: {condition_id: condition.id})),
-            class: "refine--condition-list-item",
-            data: {
-              controller: "refine--turbo-stream-link",
-              action: "refine--turbo-stream-link#visit",
-              refine__typeahead_list_target: "listItem",
-              list_item_value: condition.display
-            }
-          %>
+          <%= render partial: "condition_list_item", locals: {condition: condition } %> 
         <% end %>
       <% end %>
 
       <%  categorized_conditions.each do |(category, conditions)| %>
         <b data-refine--typeahead-list-target="category"><%= category %></b>
         <% conditions.each do |condition| %>
-          <%= link_to condition.display,
-            new_refine_inline_criterion_url(@criterion.to_params.deep_merge(refine_inline_criterion: {condition_id: condition.id})),
-            class: "refine--condition-list-item",
-            data: {
-              controller: "refine--turbo-stream-link",
-              action: "refine--turbo-stream-link#visit",
-              refine__typeahead_list_target: "listItem",
-              list_item_value: condition.display,
-              category: category
-            }
-          %>
+          <%= render partial: "condition_list_item", locals: {condition: condition, category: category } %> 
         <% end %>
       <% end %>
     </div>

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.10.1"
+    VERSION = "2.11.0"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",


### PR DESCRIPTION
Adds support for the inline UI for icons to be defined on a per-condition basis.

**Usage**
In the implementing filter, use the method `with_icon_class` or `with_icon_template` to define the icon params. If you're using a library that uses css classes and you simply want to prepend the icon, `with_icon_class` will suit your needs. If you need more control over it you can use `with_icon_template` to pass in a custom partial file and any additional locals needed. 

Wiki will be updated with more documentation after this is merged