### PR TITLE
Adding feature to clear an entire filter all at once to the inline ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 2.11.1
-  * Inline UI - Stretching toolbar to full width and floating save filter control container to the right
+  * Inline UI - Stretching toolbar to full width and floating save filter control container to the right, adds clear button
 ### 2.11.0
   * New Feature - Allow icons to be used in condition dropdowns and give configurable control over rendering of the condition item. Note - this only impacts the Inline UI
 ### 2.10.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.11.1
+  * Inline UI - Stretching toolbar to full width and floating save filter control container to the right
 ### 2.11.0
   * New Feature - Allow icons to be used in condition dropdowns and give configurable control over rendering of the condition item. Note - this only impacts the Inline UI
 ### 2.10.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.11.0)
+    refine-rails (2.11.1)
       rails (>= 6.0)
 
 GEM
@@ -102,7 +102,7 @@ GEM
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
     mysql2 (0.5.6)
-    net-imap (0.4.14)
+    net-imap (0.4.15)
       date
       net-protocol
     net-pop (0.1.2)

--- a/app/assets/stylesheets/index.tailwind.css
+++ b/app/assets/stylesheets/index.tailwind.css
@@ -906,6 +906,10 @@ input.refine--text-condition-input:focus {
   }
 }
 
+.refine--add-group-button {
+  margin-left: 10px;
+}
+
 .refine--has-many-groups .refine--add-button-label {
   display: none;
 }

--- a/app/assets/stylesheets/index.tailwind.css
+++ b/app/assets/stylesheets/index.tailwind.css
@@ -529,8 +529,8 @@
     content: "";
     position: absolute;
     right: -10px;
-    top: -2px;
-    bottom: -2px;
+    top: -6px;
+    bottom: -6px;
     border: 2px solid #eee;
     width: 3px;
   }
@@ -541,7 +541,6 @@
   }
   &:after {
     border-radius: 0 6px 6px 0;
-    right: 0;
     border-left: none;
   }
 }
@@ -876,14 +875,14 @@ input.refine--text-condition-input:focus {
 
 .refine--add-condition-button.refine--add-first-condition-button,
 .refine--add-condition-group-button.refine--add-first-condition-button {
-    border: 1px dotted #aaa;
-    padding-right: 8px;
-    line-height: 16px;
-    &:hover {
-      background-color: #fff;
-      border-style: solid;
-      color: #111;
-    }
+  border: 1px dotted #aaa;
+  padding-right: 8px;
+  line-height: 16px;
+  &:hover {
+    background-color: #fff;
+    border-style: solid;
+    color: #111;
+  }
 }
 
 .refine--add-condition-button, .refine--add-group-button {
@@ -895,6 +894,7 @@ input.refine--text-condition-input:focus {
   padding: 5px;
   align-items: center;
   background-color: #fff;
+  position: relative;
   &:disabled {
     color: #111;
     background-color: #f8f8f8;

--- a/app/assets/stylesheets/index.tailwind.css
+++ b/app/assets/stylesheets/index.tailwind.css
@@ -382,25 +382,32 @@
 .refine--filter-wrapper {
   font-size: 14px;
   display: flex;
-  flex-direction: column;
+  /* flex-direction: column; */
   gap: 12px;
   margin-top: 12px;
 }
 
 .refine--filter-row {
   display: flex;
+  width: 100%;
+  gap: 10px;
+  row-gap: 15px;
+  align-items: center;
+  align-items: start;
+  justify-content: space-between;
+}
+
+.refine--groups-wrapper {
+  flex-grow: 1;
+  display: flex;
   gap: 10px;
   row-gap: 15px;
   align-items: center;
   flex-wrap: wrap;
 }
 
-.refine--groups-wrapper {
-  display: flex;
-  gap: 10px;
-  row-gap: 15px;
-  align-items: center;
-  flex-wrap: wrap;
+.refine--filter-control-group {
+  text-wrap: nowrap;
 }
 
 .refine--group-join, .refine--condition-join {
@@ -429,6 +436,7 @@
   position: relative;
   padding: 0 10px;
   align-items: center;
+  flex-wrap: wrap;
 
   &:before , &:after {
     content: "";

--- a/app/assets/stylesheets/index.tailwind.css
+++ b/app/assets/stylesheets/index.tailwind.css
@@ -408,6 +408,7 @@
 
 .refine--filter-control-group {
   text-wrap: nowrap;
+  display: flex;
 }
 
 .refine--group-join, .refine--condition-join {
@@ -859,9 +860,6 @@ input.refine--text-condition-input:focus {
   text-decoration: none;
 }
 
-.refine--save-filter-link-label {
-  border-bottom: 1px dotted #111;
-}
 /*
   *********************************************
   Inline Final Styles
@@ -1014,16 +1012,19 @@ button.refine--apply-button {
   }
 }
 
-.refine--save-filter-link {
+.refine--save-filter-link, .refine--clear-filter-link {
   display: flex;
   align-items: center;
   gap: 5px;
   font-size: 14px;
-  padding: 3px 0;
+  padding: 3px 0 3px 10px;
   border: 1px solid transparent;
   border-radius: 6px;
 }
 
+.refine--save-filter-link-label, .refine--clear-filter-link-label {
+  border-bottom: 1px dotted #111;
+}
 .refine--save-filter-input-wrapper {
   display: flex;
   gap: 5px;

--- a/app/assets/stylesheets/index.tailwind.css
+++ b/app/assets/stylesheets/index.tailwind.css
@@ -492,11 +492,58 @@
   text-decoration: none;
 }
 
-.refine--condition-pill-wrapper-wrapper {
+.refine--condition-pill-wrapper {
   display: flex;
   align-items: center;
   gap: 5px;
   position: relative;
+}
+
+.refine--condition-pill-start {
+  padding: 0 0 0 10px;
+  &:before {
+    content: "";
+    position: absolute;
+    left: -10px;
+    top: -2px;
+    bottom: -2px;
+    border: 2px solid #eee;
+    width: 3px;
+  }
+  &:hover {
+    &:before{
+      border-color: #aaa;
+    }
+  }
+  &:before {
+    border-radius: 6px 0 0 6px;
+    left: 0;
+    border-right: none;
+  }
+  
+}
+
+.refine--condition-pill-end {
+  padding: 0 10px 0 0;
+  &:after {
+    content: "";
+    position: absolute;
+    right: -10px;
+    top: -2px;
+    bottom: -2px;
+    border: 2px solid #eee;
+    width: 3px;
+  }
+  &:hover {
+    &:after {
+      border-color: #aaa;
+    }
+  }
+  &:after {
+    border-radius: 0 6px 6px 0;
+    right: 0;
+    border-left: none;
+  }
 }
 
 .refine--condition-pill {

--- a/app/controllers/refine/inline/criteria_controller.rb
+++ b/app/controllers/refine/inline/criteria_controller.rb
@@ -88,10 +88,7 @@ class Refine::Inline::CriteriaController < ApplicationController
   end
 
   def clear
-    puts "CLEARING filter"
-    puts @refine_filter.blueprint.inspect
     @refine_filter.clear_blueprint!
-    puts @refine_filter.blueprint.inspect
     @criterion = Refine::Inline::Criterion.new(criterion_params.merge(refine_filter: @refine_filter))
     handle_filter_update()
   end

--- a/app/models/refine/filter.rb
+++ b/app/models/refine/filter.rb
@@ -316,5 +316,9 @@ module Refine
     def has_category_ordering?
       respond_to?(:category_order) && category_order.is_a?(Array) && category_order.any?
     end
+
+    def clear_blueprint!
+      @blueprint = []
+    end
   end
 end

--- a/app/views/refine/inline/filters/_and_button.html.erb
+++ b/app/views/refine/inline/filters/_and_button.html.erb
@@ -9,7 +9,7 @@
 %>
 
 <% if @refine_filter.criteria_limit_reached? %>
-  <button disabled class="refine--add-condition-button refine--group-last-item" type="button" title="<%= t(".criteria_limit", criteria_limit: @refine_filter.criteria_limit) %>">
+  <button disabled class="refine--add-condition-button refine--group-last-item refine--condition-pill-end" type="button" title="<%= t(".criteria_limit", criteria_limit: @refine_filter.criteria_limit) %>">
     <span class="icon material-icons-outlined refine--icon-sm">add</span>
     <span class="refine--add-button-label"><%= t("refine.inline.filters.and_button.condition") %></span>
   </button>
@@ -18,7 +18,7 @@
     frame_id: dom_id(criterion),
     src: refine_inline_criteria_path(criterion.to_params) do
   %>
-    <button class="refine--add-condition-button refine--group-last-item" type="button" data-action="click->refine--popup#show">
+    <button class="refine--add-condition-button refine--group-last-item refine--condition-pill-end" type="button" data-action="click->refine--popup#show">
       <span class="icon material-icons-outlined refine--icon-sm">add</span>
       <span class="refine--add-button-label"><%= t("refine.inline.filters.and_button.condition") %></span>
     </button>

--- a/app/views/refine/inline/filters/_and_button.html.erb
+++ b/app/views/refine/inline/filters/_and_button.html.erb
@@ -9,7 +9,7 @@
 %>
 
 <% if @refine_filter.criteria_limit_reached? %>
-  <button disabled class="refine--add-condition-button" type="button" title="<%= t(".criteria_limit", criteria_limit: @refine_filter.criteria_limit) %>">
+  <button disabled class="refine--add-condition-button refine--group-last-item" type="button" title="<%= t(".criteria_limit", criteria_limit: @refine_filter.criteria_limit) %>">
     <span class="icon material-icons-outlined refine--icon-sm">add</span>
     <span class="refine--add-button-label"><%= t("refine.inline.filters.and_button.condition") %></span>
   </button>
@@ -18,7 +18,7 @@
     frame_id: dom_id(criterion),
     src: refine_inline_criteria_path(criterion.to_params) do
   %>
-    <button class="refine--add-condition-button" type="button" data-action="click->refine--popup#show">
+    <button class="refine--add-condition-button refine--group-last-item" type="button" data-action="click->refine--popup#show">
       <span class="icon material-icons-outlined refine--icon-sm">add</span>
       <span class="refine--add-button-label"><%= t("refine.inline.filters.and_button.condition") %></span>
     </button>

--- a/app/views/refine/inline/filters/_clear_button.html.erb
+++ b/app/views/refine/inline/filters/_clear_button.html.erb
@@ -1,0 +1,13 @@
+<% 
+  criterion = Refine::Inline::Criterion.new(
+    stable_id: @refine_filter.to_stable_id,
+    client_id: @refine_client_id,
+  )
+%>
+
+<%= link_to clear_refine_inline_criteria_path(criterion.to_params), method: :post,
+  class: "refine--clear-filter-link", data: {turbo_stream: true, turbo_method: :post} do %>
+    <span class="material-icons-outlined refine--icon-sm">clear</span>
+    <span class="refine--clear-filter-link-label"><%= t('refine.inline.filters.clear_filter') %></span>
+<% end %>
+

--- a/app/views/refine/inline/filters/_criterion.html.erb
+++ b/app/views/refine/inline/filters/_criterion.html.erb
@@ -1,10 +1,18 @@
 <%# Filter Pill partial %>
+<% 
+puts "CRITERION VARS: #{placement}, #{size}"
+  pill_class = if placement == 0
+    "refine--condition-pill-start"
+  elsif placement == size - 1
+    "refine--condition-pill-last"
+  end
+%>
 
 <%= render "refine/inline/filters/popup",
   frame_id: dom_id(criterion) do
 %>
 
-  <div class="refine--condition-pill-wrapper">
+  <div class="refine--condition-pill-wrapper <%= pill_class %>">
     <div class="refine--condition-pill">
       <%= link_to criterion.condition_display, edit_refine_inline_criterion_path(criterion.position, criterion.to_params), class: "refine--condition-pill-name", data: {controller: "refine--turbo-stream-link", action: "refine--turbo-stream-link#visit"} %>
       <div class="refine--remove-condition"></div>

--- a/app/views/refine/inline/filters/_criterion.html.erb
+++ b/app/views/refine/inline/filters/_criterion.html.erb
@@ -1,10 +1,7 @@
 <%# Filter Pill partial %>
 <% 
-puts "CRITERION VARS: #{placement}, #{size}"
   pill_class = if placement == 0
     "refine--condition-pill-start"
-  elsif placement == size - 1
-    "refine--condition-pill-last"
   end
 %>
 

--- a/app/views/refine/inline/filters/_group.html.erb
+++ b/app/views/refine/inline/filters/_group.html.erb
@@ -2,6 +2,6 @@
   <% unless i == 0 %>
     <div class="refine--condition-join"><%= t(".and") %></div>
   <% end %>
-  <%= render "refine/inline/filters/criterion", criterion: criterion %>
+  <%= render "refine/inline/filters/criterion", criterion: criterion, placement: i, size: group.length %>
 <% end %>
 <%= render "refine/inline/filters/and_button", position: group.last.position + 1 %>

--- a/app/views/refine/inline/filters/_group.html.erb
+++ b/app/views/refine/inline/filters/_group.html.erb
@@ -1,13 +1,7 @@
-<div class="refine--group">
-  <div class="refine--group-conditions-wrapper">
-    <div class="refine--group-conditions">
-      <% group.each.with_index do |criterion, i| %>
-        <% unless i == 0 %>
-          <div class="refine--condition-join"><%= t(".and") %></div>
-        <% end %>
-        <%= render "refine/inline/filters/criterion", criterion: criterion %>
-      <% end %>
-    </div>
-    <%= render "refine/inline/filters/and_button", position: group.last.position + 1 %>
-  </div>
-</div>
+<% group.each.with_index do |criterion, i| %>
+  <% unless i == 0 %>
+    <div class="refine--condition-join"><%= t(".and") %></div>
+  <% end %>
+  <%= render "refine/inline/filters/criterion", criterion: criterion %>
+<% end %>
+<%= render "refine/inline/filters/and_button", position: group.last.position + 1 %>

--- a/app/views/refine/inline/filters/_show.html.erb
+++ b/app/views/refine/inline/filters/_show.html.erb
@@ -17,15 +17,10 @@
           <% unless i == 0 %>
               <div class="refine--group-join"><%= t("refine.inline.filters.or") %></div>
             <% end %>
-          <div class="refine--group">
-            
-            <div class="refine--group-conditions-wrapper">
-              <%= render "refine/inline/filters/group", group: group %>
-            </div>
+            <%= render "refine/inline/filters/group", group: group %>
             <% if i == groups.length - 1 %>
               <%= render "refine/inline/filters/or_button", position: @refine_filter.blueprint.length %>
             <% end %>
-          </div>
         <% end %>
 
       </div>

--- a/app/views/refine/inline/filters/_show.html.erb
+++ b/app/views/refine/inline/filters/_show.html.erb
@@ -1,38 +1,42 @@
 <%
   groups = Refine::Inline::Criterion.groups_from_filter(@refine_filter, client_id: @refine_client_id, stable_id: @refine_stable_id)
 
+  root_data = (defined?(data) && data) || {}
+
   main_row_class = class_names "refine--filter-row" => true,
     "refine--has-many-groups" => groups.many?
 %>
 
-<%= tag.div class: "refine--filter-wrapper", id: "refine-inline-filter-#{@refine_client_id}" do %>
+<%= tag.div class: "refine--filter-wrapper", id: "refine-inline-filter-#{@refine_client_id}", data: root_data do %>
   <%= tag.div class: main_row_class do %>
     <% if @refine_filter.blueprint.empty? %>
-      <%= render "refine/inline/filters/add_first_condition_button", position: 0, btn_class: "
-      refine--add-first-condition-btn" %>
+      <%= render "refine/inline/filters/add_first_condition_button", position: 0, btn_class: "refine--add-first-condition-btn" %>
     <% else %>
-      <div class="refine--filter-label">
-        <%= t('refine.inline.filters.filter') %>: 
-      </div>
       <div class="refine--groups-wrapper">
         <% groups.each.with_index do |group, i| %>
           <% unless i == 0 %>
-            <div class="refine--group-join"><%= t("refine.inline.filters.or") %></div>
-          <% end %>
-
-          <%= render "refine/inline/filters/group", group: group %>
+              <div class="refine--group-join"><%= t("refine.inline.filters.or") %></div>
+            <% end %>
+          <div class="refine--group">
+            
+            <div class="refine--group-conditions-wrapper">
+              <%= render "refine/inline/filters/group", group: group %>
+            </div>
+            <% if i == groups.length - 1 %>
+              <%= render "refine/inline/filters/or_button", position: @refine_filter.blueprint.length %>
+            <% end %>
+          </div>
         <% end %>
 
-        <div class="refine--group">
-          <div class="refine--group-conditions-wrapper">
-            <%= render "refine/inline/filters/or_button", position: @refine_filter.blueprint.length %>
-          </div>
-        </div>
-        <%= render "refine/inline/filters/save_button" %>
-        
       </div>
     <% end %>
+   <% if @refine_filter.blueprint&.any? %>
+      <div class="refine--filter-control-group">
+        <%= render "refine/inline/filters/save_button" %>
+      </div>
+    <% end %> 
   <% end %>
+  
 <% end %>
 
 

--- a/app/views/refine/inline/filters/_show.html.erb
+++ b/app/views/refine/inline/filters/_show.html.erb
@@ -27,6 +27,7 @@
     <% end %>
    <% if @refine_filter.blueprint&.any? %>
       <div class="refine--filter-control-group">
+        <%= render "refine/inline/filters/clear_button" %>
         <%= render "refine/inline/filters/save_button" %>
       </div>
     <% end %> 

--- a/config/locales/en/refine.en.yml
+++ b/config/locales/en/refine.en.yml
@@ -58,7 +58,8 @@ en:
         or_button: "+ Add OR Group"
         filter: "Filter"
         criteria_limit: "You can only create up to %{criteria_limit} filter conditions"
-        save_filter: "Save Filter"
+        save_filter: "Save"
+        clear_filter: "Clear"
         or: "or"
         clear: "clear"
       inputs:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,9 @@ Rails.application.routes.draw do
       post "find", on: :collection
     end
     namespace :inline do
-      resources :criteria, except: [:show]
+      resources :criteria, except: [:show] do
+        post "clear", on: :collection
+      end
       resources :stored_filters, only: [:index, :new, :create] do
         post "find", on: :collection
       end

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.11.0"
+    VERSION = "2.11.1"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",


### PR DESCRIPTION
Closed https://github.com/clickfunnels2/refine-rails/pull/188/files in favor of this PR
Laying foundation for an upcoming revamp of the inline UI.
This does the following:

Reworks HTML structure so that the "Save filter" component sits on the right hand side of the toolbar
The left part of the toolbar does a flex-wrap in a way such that the individual components will wrap smartly depending on screen real-estate

This adds a clear button to an active Inline UI filter that will appear next to the Save button. When pressed, this will clear out all the blueprints from the filter and trigger a submit-success event