### PR TITLE
Bugfix criteria controller params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 2.11.7
+### 2.11.8
   * Bugfix - fixing an issue where params being passed for fill_modal wouldn't process correctly
 ### 2.11.6
   * WIP Feature - Adds initial framework to support a Shoelace modal component for condition selection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.11.7
+  * Bugfix - fixing an issue where params being passed for fill_modal wouldn't process correctly
 ### 2.11.6
   * WIP Feature - Adds initial framework to support a Shoelace modal component for condition selection.
 ### 2.11.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.11.6)
+    refine-rails (2.11.7)
       rails (>= 6.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.11.7)
+    refine-rails (2.11.8)
       rails (>= 6.0)
 
 GEM

--- a/app/controllers/refine/inline/criteria_controller.rb
+++ b/app/controllers/refine/inline/criteria_controller.rb
@@ -13,7 +13,7 @@ class Refine::Inline::CriteriaController < ApplicationController
   def index_advanced
     @criterion = Refine::Inline::Criterion.new(criterion_params.merge(refine_filter: @refine_filter))
     @conditions = @refine_filter.instantiated_conditions
-    @fill_modal = params[:fill_modal]
+    @fill_modal = params[:fill_modal] && params[:fill_modal] == "true"
   end
 
   # Show the form to add a new criteria

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.11.6"
+    VERSION = "2.11.7"
   end
 end

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.11.7"
+    VERSION = "2.11.8"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.11.7",
+  "version": "2.11.8",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.11.6",
+  "version": "2.11.7",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",


### PR DESCRIPTION
In the previous PR there was a bug in how criteria_controller handled the fill_modal param. this fixes that. I also mucked up the release of 2.11.7 so this bumps straight to 2.11.8