### PR TITLE
Trim blank space from inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.11.12
+  * Trims inputs in old and new UIs for values to remove leading and trailing whitespace
 ### 2.11.11
   * WIP Feature - Advanced Condition Select: Adding stimulus controller for modal. Hides search bar if attributes tab is not active
 ### 2.11.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.11.11)
+    refine-rails (2.11.12)
       rails (>= 6.0)
 
 GEM
@@ -102,7 +102,7 @@ GEM
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
     mysql2 (0.5.6)
-    net-imap (0.5.0)
+    net-imap (0.5.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -179,7 +179,7 @@ GEM
       rubocop (= 1.35.1)
       rubocop-performance (= 1.14.3)
     thor (1.3.2)
-    timeout (0.4.1)
+    timeout (0.4.2)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)

--- a/app/javascript/controllers/refine/update-controller.js
+++ b/app/javascript/controllers/refine/update-controller.js
@@ -55,6 +55,7 @@ export default class extends ServerRefreshController {
     const inputId = dataset.inputId
     inputKey = inputKey || dataset.inputKey || 'value'
     value = value || event.target.value
+    value = value.trim()
     state.updateInput(
       criterionIdValue,
       {

--- a/app/models/refine/inline/criteria/input.rb
+++ b/app/models/refine/inline/criteria/input.rb
@@ -18,6 +18,7 @@ class Refine::Inline::Criteria::Input
   :count_refinement,
   :date_refinement
 
+
   def attributes
     {
       clause: clause,
@@ -32,6 +33,11 @@ class Refine::Inline::Criteria::Input
       count_refinement: count_refinement_attributes.presence,
       date_refinement: date_refinement_attributes.presence
     }.compact
+  end
+
+  def attributes=(attrs = {})
+    super(attrs)
+    strip_values
   end
 
   def count_refinement
@@ -60,5 +66,12 @@ class Refine::Inline::Criteria::Input
 
   def selected=(value)
     @selected = Array.wrap(value)
+  end
+
+  def strip_values
+    [:value, :value1, :value2].each do |attr|
+      current_value = send(attr)
+      send("#{attr}=", current_value.strip) if current_value.present?
+    end
   end
 end

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.11.11"
+    VERSION = "2.11.12"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.11.11",
+  "version": "2.11.12",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",

--- a/test/refine/models/inline/criteria/input_test.rb
+++ b/test/refine/models/inline/criteria/input_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+require "support/refine/test_double_filter"
+require "refine/invalid_filter_error"
+
+describe Refine::Inline::Criteria::Input do
+  describe "strip_values" do  
+    it "strips leading and trailing whitespace from all string values" do
+      input = Refine::Inline::Criteria::Input.new({"value" => "  value  ", "value1" => "  value1", "value2" => "value2  "})
+      input.strip_values
+      assert_equal({value: "value", value1: "value1", value2: "value2"}, input.attributes.slice(:value, :value1, :value2))
+    end
+  end
+end


### PR DESCRIPTION
This adds logic into both the old and new UIs to trim leading and trailing whitespace from string inputs (text and numeric conditions specfically)

