### PR TITLE
Category picker improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.12.1
+  * Category Picker - smooths out category picker and makes search mutually exclusive
 ### 2.12.0
   * Feature Release - Advanced Condition Select: Fully releases a new option for condition selects built for more complex filters
   * Fixes a bug with 2.11.12 where a is_one_of and is_not_one_of clause would break the old UI

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.12.0)
+    refine-rails (2.12.1)
       rails (>= 6.0)
 
 GEM

--- a/app/javascript/controllers/refine/inline-advanced-modal-controller.js
+++ b/app/javascript/controllers/refine/inline-advanced-modal-controller.js
@@ -93,18 +93,18 @@ export default class extends Controller {
   scrollToCategory(event) {
     const categoryName = event.target.dataset.inlineAdvancedModalValue
     const categoryElement = this.findCategoryElementByName(categoryName)
-    this.shouldHighlightCategories = false;
     if(categoryElement) {
+      this.shouldHighlightCategories = false;
       categoryElement.scrollIntoView({
         behavior: "smooth",
         block: "start",
         inline: "nearest"
       })
+      setTimeout(() => {
+        this.shouldHighlightCategories = true;
+        this.highlightCategory(categoryName, true);
+      }, 750);
     }
-    setTimeout(() => {
-      this.shouldHighlightCategories = true;
-      this.highlightCategory(categoryName, true);
-    }, 750);
   }
 
   debounceScrollHighlights() {

--- a/app/javascript/controllers/refine/inline-advanced-modal-controller.js
+++ b/app/javascript/controllers/refine/inline-advanced-modal-controller.js
@@ -2,38 +2,66 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
 
-  static targets = ['searchBarInput', 'categoryListItem', 'categoryBlockItem', 'categoryShortcutItem']
+  static targets = ['searchBarInput', 'categoryListItem', 'categoryBlockItem', 'categoryShortcutItem', 'scrollContainer']
 
   connect() {
     this.observer = new IntersectionObserver(
       this.handleIntersection.bind(this), {
-        threshold: 1
+        root: this.scrollContainerTarget,
+        threshold: 1.0,
+        rootMargin: '0px 0px -80% 0px'
       }
     )
 
-    this.categoryBlockItemTargets.forEach(item => this.observer.observe(item))
+    this.bottomObserver = new IntersectionObserver(
+      this.handleBottomIntersection.bind(this), {
+        root: this.scrollContainerTarget,
+        threshold: 1.0
+      }
+    )
+
+    this.shouldHighlightCategories = true;
+    this.handleHighlightTimeout = null;
+    this.bottomMarker = document.getElementById('refine--picker-bottom-marker');
+
+    this.categoryListItemTargets.forEach(item => this.observer.observe(item))
+    this.bottomObserver.observe(this.bottomMarker)
   }
 
   disconnect() {
+    this.bottomObserver.disconnect()
     this.observer.disconnect()
   }
 
   handleIntersection(entries) {
     entries.forEach(entry => {
-      if(entry.isIntersecting) {
-        this.highlightCategory(entry.target.dataset.categoryListBlockValue)
+      if (entry.isIntersecting && entry.target !== this.bottomMarker) {
+        if(entry.intersectionRatio == 1) {
+          this.highlightCategory(entry.target.dataset.categoryListItemValue)
+        }
       }
     })
   }
 
-  highlightCategory(categoryName) {
-    this.categoryShortcutItemTargets.forEach(item => {
-      if(item.dataset.inlineAdvancedModalValue === categoryName) {
-        item.classList.add('active')
-      } else {
-        item.classList.remove('active')
+  handleBottomIntersection(entries) {
+    entries.forEach(entry => {
+      if (entry.isIntersecting && entry.target === this.bottomMarker) {
+        this.highlightCategory(this.categoryListItemTargets[this.categoryListItemTargets.length - 1].dataset.categoryListItemValue)
       }
     })
+  }
+    
+
+  highlightCategory(categoryName, force=false) {
+    if(this.shouldHighlightCategories || force) {
+      this.categoryShortcutItemTargets.forEach(item => {
+        if(item.dataset.inlineAdvancedModalValue === categoryName) {
+          item.classList.add('active')
+        } else {
+          item.classList.remove('active')
+        }
+      })
+    }
   }
 
   showSearchBar() {
@@ -49,9 +77,23 @@ export default class extends Controller {
     return this.categoryListItemTargets.find(item => item.dataset.categoryListItemValue === categoryName)
   }
 
+  clearSelection() {
+    this.debounceScrollHighlights();
+    this.categoryShortcutItemTargets.forEach((item) => {
+      item.classList.remove('active')
+    })
+  }
+
+  clearSearch() {
+    if (this.searchBarInputTarget.querySelector("input")) {
+      this.searchBarInputTarget.querySelector("input").value = ''
+    }
+  }
+
   scrollToCategory(event) {
     const categoryName = event.target.dataset.inlineAdvancedModalValue
     const categoryElement = this.findCategoryElementByName(categoryName)
+    this.shouldHighlightCategories = false;
     if(categoryElement) {
       categoryElement.scrollIntoView({
         behavior: "smooth",
@@ -59,6 +101,18 @@ export default class extends Controller {
         inline: "nearest"
       })
     }
+    setTimeout(() => {
+      this.shouldHighlightCategories = true;
+      this.highlightCategory(categoryName, true);
+    }, 750);
+  }
+
+  debounceScrollHighlights() {
+    this.shouldHighlightCategories = false;
+    clearTimeout(this.handleHighlightTimeout);
+    this.handleHighlightTimeout = setTimeout(() => {
+      this.shouldHighlightCategories = true;
+    }, 1000)
   }
   
 }

--- a/app/javascript/controllers/refine/typeahead-list-controller.js
+++ b/app/javascript/controllers/refine/typeahead-list-controller.js
@@ -6,6 +6,14 @@ export default class extends Controller {
 
   filter(event) {
     const query = event.currentTarget.value.toLowerCase()
+    this.handleFilter(query) 
+  }
+
+  clearSearch() {
+    this.handleFilter('')
+  }
+
+  handleFilter(query) {
     const visibleCategories = new Set()
 
     // hide / show listItem links that match the query and note which

--- a/app/views/refine/advanced_inline/criteria/index.html.erb
+++ b/app/views/refine/advanced_inline/criteria/index.html.erb
@@ -29,11 +29,11 @@
       </h2>
       <div part="header-actions" class="refine--modal-header-actions ">
         <slot name="header-actions"></slot>
-        <div class="refine--filter-condition-search" data-refine--inline-advanced-modal-target="searchBarInput">
+        <div class="refine--filter-condition-search" data-refine--inline-advanced-modal-target="searchBarInput" >
           <div class="absolute inset-y-0 left-0 pl-3 pr-2 flex items-center pointer-events-none" aria-hidden="true">
             <i class="text-coolGray-600 dark:text-coolGray-200 fa-regular fa-magnifying-glass" ></i>
           </div>
-          <input type="text" class="input input--search" placeholder="<%= t(".search_attributes") %>" data-search-target="filterProperties" data-action="refine--typeahead-list#filter" />
+          <input type="text" class="input input--search" placeholder="<%= t(".search_attributes") %>" data-search-target="filterProperties" data-action="refine--typeahead-list#filter refine--inline-advanced-modal#clearSelection" />
         </div>
         <sl-icon-button part="close-button" exportparts="base:close-button__base refine--modal-close" class="dialog__close" name="x-lg" library="system" label="Close" data-action="click->refine--modal#close"></sl-icon-button>
       </div>
@@ -56,7 +56,7 @@
             <div class="refine--advanced-category-picker">
               <% categorized_conditions.each do |category, conditions| %>
                 <div class="refine--condition-list-item refine--condition-list-card" 
-                  data-action="click->refine--inline-advanced-modal#scrollToCategory"
+                  data-action="click->refine--inline-advanced-modal#clearSearch click->refine--typeahead-list#clearSearch click->refine--inline-advanced-modal#scrollToCategory "
                   data-inline-advanced-modal-value="<%= category %>"
                   data-refine--inline-advanced-modal-target="categoryShortcutItem"
                 >
@@ -68,7 +68,7 @@
               <% end %>
             </div>
           <% end %>
-          <div class="refine--advanced-condition-picker <%= "lone" if categorized_conditions&.empty? %>">
+          <div data-refine--inline-advanced-modal-target="scrollContainer" class="refine--advanced-condition-picker <%= "lone" if categorized_conditions&.empty? %>">
             <% if uncategorized_conditions&.any? %>
               <div class="refine--advanced-condition-select-group">
                 <% uncategorized_conditions.each do |condition| %>
@@ -94,13 +94,14 @@
                 <% end %>
               </div>
             <% end %>
+            <div id="refine--picker-bottom-marker" data-refine--inline-advanced-modal-target="categoryBlockItem" data-category-list-block-value="bottom"></div>
           </div>
         </div>
       </sl-tab-panel>
 
       <sl-tab-panel name="saved_filters" class="refine--advanced-condition-select">
         <%= turbo_frame_tag dom_id(@criterion, :load), src: refine_advanced_inline_stored_filters_path(@criterion.to_params), loading: :lazy do %>
-          <div class="flex items-center justify-center p-9">
+          <div class="refine--saved-filters-panel">
             <%= sl_component(:spinner, class: "sl-spinner--medium") %>
           </div> 
         <% end %>

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.12.0"
+    VERSION = "2.12.1"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",


### PR DESCRIPTION
This PR cleans up some of the interactions with the category picker javascript for a couple focus points:
1. Scroll highlighting works on the header rather than the blocks.
2. Adds a hidden 'bottom' element handler which will select the bottom element if in view. This prevents the issue of the end of list never highlighting
3. Smooths out category selection to not flicker highlighting
4. when searching, category highlighting is removed
5. when category is picked, search is cleared.