### PR TITLE
DO NOT MERGE - Very rough POC for better query smarts

### DIFF
--- a/app/models/refine/conditions/condition.rb
+++ b/app/models/refine/conditions/condition.rb
@@ -121,8 +121,9 @@ module Refine::Conditions
     # @param [Hash] input The user's input
     # @param [Arel::Table] table The arel_table the query is built on 
     # @param [ActiveRecord::Relation] initial_query The base query the query is built on 
+    # @param [string] through_attribute if this is a has_many :through relationship the child attribute to apply the where clause to
     # @return [Arel::Node] 
-    def apply(input, table, initial_query, inverse_clause=false)
+    def apply(input, table, initial_query, inverse_clause=false, through_attribute=nil)
       table ||= filter.table
       # Ensurance validations are checking the developer configured correctly
       run_ensurance_validations
@@ -145,12 +146,18 @@ module Refine::Conditions
         input.delete(:filter_refinement)
       end
 
+      puts "condition.rb: is_relationship_attribute? #{is_relationship_attribute?}"
+      puts "condition.rb: input: #{input.inspect}"
       if is_relationship_attribute?
         apply_relationship_attribute(input: input, query: initial_query)
         return
       end
       # No longer a relationship attribute, apply condition normally
-      nodes = apply_condition(input, table, inverse_clause)
+      puts "condition.rb: applying normal condition"
+      puts "condition.rb: input: #{input.inspect}"
+      puts "condition.rb: table: #{table.inspect}"
+      puts "condition.rb: inverse_clause: #{inverse_clause}"
+      nodes = apply_condition(input, table, inverse_clause, through_attribute)
       if !is_refinement && has_any_refinements?
         refined_node = apply_refinements(input)
         # Count refinement will return nil because it directly modified pending relationship subquery

--- a/app/models/refine/conditions/option_condition.rb
+++ b/app/models/refine/conditions/option_condition.rb
@@ -144,11 +144,13 @@ module Refine::Conditions
       ]
     end
 
-    def apply_condition(input, table, inverse_clause)
+    def apply_condition(input, table, inverse_clause, through_attribute=nil)
       value = input[:selected]
       # TODO: Triggers on "through" relationship. Other relationships?
       @clause = CLAUSE_IN if inverse_clause
-
+      puts "apply_condition: #{value.inspect} : #{table} : #{attribute} : through_attribute: #{through_attribute}"
+      self.attribute = through_attribute if through_attribute
+      puts "overridding attribute: #{attribute}"
       case clause
       when CLAUSE_SET
         apply_clause_set(table)
@@ -220,6 +222,7 @@ module Refine::Conditions
     def apply_clause_not_in(value, table)
       normalized_values = values_for_application(value)
       # Must check for only nil option selected here
+      puts "apply_clause_not_in value: #{value.inspect} : #{normalized_values.inspect} : #{table} : #{attribute}"
       if nil_option_selected?(value) && value.one?
         table.grouping(table[:"#{attribute}"].not_eq(nil))
       elsif nil_option_selected?(value)
@@ -256,5 +259,7 @@ module Refine::Conditions
     def apply_clause_not_set(table)
       table.grouping(table[:"#{attribute}"].eq_any([nil, ""]))
     end
+
+
   end
 end

--- a/app/models/refine/filter.rb
+++ b/app/models/refine/filter.rb
@@ -19,6 +19,7 @@ module Refine
 
     cattr_accessor :default_stabilizer, default: nil, instance_accessor: false
     cattr_accessor :criteria_limit, default: 5, instance_accessor: true
+    cattr_accessor :recursive_count, default: 0, instance_accessor: true
 
     attr_reader :blueprint, :initial_query
 
@@ -90,6 +91,7 @@ module Refine
 
     def get_query
       raise "Initial query must exist" if initial_query.nil?
+      puts "END REFINE FILTER QUERY: #{@relation.to_sql}"
       if blueprint.present?
         @relation.where(group(make_sub_query(blueprint)))
       else

--- a/app/models/refine/tracks_pending_relationship_subqueries.rb
+++ b/app/models/refine/tracks_pending_relationship_subqueries.rb
@@ -148,6 +148,7 @@ module Refine
         current_model = subquery[:instance]&.klass 
         parent_model = subquery[:instance]&.active_record
         use_multiple_databases = (inner_query.is_a? Arel::SelectManager) && use_multiple_databases?(current_model, parent_model)
+
         if query.present?
           # If query exists and is a Select Manager we are deeply nested and need to build the query
           # with a WHERE statement
@@ -177,7 +178,15 @@ module Refine
             array_of_ids = current_model.connection.exec_query(inner_query.to_sql).rows.flatten
             query = parent_table[linking_key.to_s].send(connecting_method, array_of_ids.uniq)
           else
+            puts "TOP LEVEL"
+            self.recursive_count += 1
+            puts "recursive count: #{self.recursive_count}"
+            puts "linking_key: #{linking_key}"
+            puts "connecting_method: #{connecting_method}"
+            puts "inner_query: #{inner_query.to_sql}"
             query = parent_table[linking_key.to_s].send(connecting_method, inner_query)
+            # puts inner_query.to_sql
+            puts query.to_sql
           end
         end
       end


### PR DESCRIPTION
Old Query:
```
SELECT `contacts`.* FROM `contacts` WHERE `contacts`.`workspace_id` = 3 AND `contacts`.`billable` = TRUE AND ((contacts.id NOT IN ( SELECT contacts.id FROM contacts INNER JOIN contacts_applied_tags ON contacts_applied_tags.contact_id = contacts.id INNER JOIN contacts_tags ON contacts_tags.id = contacts_applied_tags.tag_id WHERE (contacts_tags.id IN (2, 3)) ))
```
Updated Query:
```
SELECT contacts.* FROM contacts WHERE contacts.workspace_id = 3 AND contacts.billable = TRUE AND (contacts.id NOT IN (SELECT contacts_applied_tags.contact_id FROM contacts_applied_tags WHERE (contacts_applied_tags.tag_id IN (3, 4)))) ORDER BY contacts.created_at DESC
```
Was able to figure out a way within the gem to make it smart enough to do this has_many through association without needing to do 2 inner joins. There is a lot of work to make this truly production ready and its very tied to the assumption that we're referencing the ID attribute of the child object. If we need to fetch anything else we'll have to do at least some of the joins. That nuance will come with a full ticket tackling this problem though

https://www.loom.com/share/5e8d79ac075c4c5089d3adf9499b3ce1