### PR TITLE
Performance Improvements for has_many through queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.13.0
+  * Feature Release - Adds ability to tell refine to handle join tables more efficiently
+  * Adds ability for user to force an index for a through relationship
+### 2.12.2
+  * Advanced Condition Select: Fixes card styling to truncate automatically
 ### 2.12.1
   * Category Picker - smooths out category picker and makes search mutually exclusive
 ### 2.12.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.12.2)
+    refine-rails (2.13.0)
       rails (>= 6.0)
 
 GEM
@@ -102,7 +102,7 @@ GEM
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
     mysql2 (0.5.6)
-    net-imap (0.5.1)
+    net-imap (0.5.2)
       date
       net-protocol
     net-pop (0.1.2)
@@ -179,7 +179,7 @@ GEM
       rubocop (= 1.35.1)
       rubocop-performance (= 1.14.3)
     thor (1.3.2)
-    timeout (0.4.2)
+    timeout (0.4.3)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)

--- a/app/models/refine/conditions/condition.rb
+++ b/app/models/refine/conditions/condition.rb
@@ -10,6 +10,8 @@ module Refine::Conditions
     include HasMeta
     include UsesAttributes
     include HasRefinements
+    include HasThroughIdRelationship
+    include WithForcedIndex
     include HasIcon
 
     attr_reader :ensurances, :before_validations, :clause, :filter
@@ -122,7 +124,7 @@ module Refine::Conditions
     # @param [Arel::Table] table The arel_table the query is built on 
     # @param [ActiveRecord::Relation] initial_query The base query the query is built on 
     # @return [Arel::Node] 
-    def apply(input, table, initial_query, inverse_clause=false)
+    def apply(input, table, initial_query, inverse_clause=false, through_attribute=nil)
       table ||= filter.table
       # Ensurance validations are checking the developer configured correctly
       run_ensurance_validations
@@ -150,6 +152,7 @@ module Refine::Conditions
         return
       end
       # No longer a relationship attribute, apply condition normally
+      self.attribute = through_attribute if through_attribute
       nodes = apply_condition(input, table, inverse_clause)
       if !is_refinement && has_any_refinements?
         refined_node = apply_refinements(input)

--- a/app/models/refine/conditions/has_through_id_relationship.rb
+++ b/app/models/refine/conditions/has_through_id_relationship.rb
@@ -1,0 +1,10 @@
+module Refine::Conditions::HasThroughIdRelationship
+  def through_id_relationship
+    @through_id_relationship ||= false
+  end
+
+  def with_through_id_relationship
+    @through_id_relationship = true
+    self
+  end
+end

--- a/app/models/refine/conditions/with_forced_index.rb
+++ b/app/models/refine/conditions/with_forced_index.rb
@@ -1,0 +1,10 @@
+module Refine::Conditions::WithForcedIndex
+  def forced_index
+    @forced_index ||= nil
+  end
+
+  def with_forced_index(index_string)
+    @forced_index = index_string
+    self
+  end
+end

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.12.2"
+    VERSION = "2.13.0"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.12.2",
+  "version": "2.13.0",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",


### PR DESCRIPTION
This PR introduces two optional improvements to conditions that allow for more efficient queries. These are specifically for conditions referencing a has_many :through association.

The two features are:
`.with_through_id_relationship` - this is simply a bool flag to tell Refine that we expect this to be an id attribute through an association. That way we can shortcut our queries to simply fetch the source primary_key and the target primary_key with the joins table rather than having to run two separate inner_joins to bridge the 3 tables

`.with_forced_index(index_name)` - Adds a `FORCE INDEX()` wrapper with the FROM query in the subquery generated for the condition. 

So it will change a query like 
```
SELECT `contacts`.* FROM `contacts` WHERE `contacts`.`workspace_id` = 3 AND `contacts`.`billable` = TRUE AND (`contacts`.`id` IN (SELECT `contacts`.`id` FROM `contacts` INNER JOIN `contacts_applied_tags` ON `contacts_applied_tags`.`contact_id` = `contacts`.`id` INNER JOIN `contacts_tags` ON `contacts_tags`.`id` = `contacts_applied_tags`.`tag_id` WHERE (`contacts_tags`.`id` IN (2, 3))))
```

To
```
SELECT `contacts`.* FROM `contacts` WHERE `contacts`.`workspace_id` = 3 AND `contacts`.`billable` = TRUE AND (`contacts`.`id` IN (SELECT `contacts_applied_tags`.`contact_id` FROM `contacts_applied_tags` FORCE INDEX(`index_contacts_applied_tags_on_contact_id`) WHERE (`contacts_applied_tags`.`tag_id` IN (2, 3))))
```
