### PR TITLE
Further through id improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.13.1
+  * Patch for new through relationship efficiency to handle nested relations and scope procs correctly
 ### 2.13.0
   * Feature Release - Adds ability to tell refine to handle join tables more efficiently
   * Adds ability for user to force an index for a through relationship

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.13.0)
+    refine-rails (2.13.1)
       rails (>= 6.0)
 
 GEM
@@ -102,7 +102,7 @@ GEM
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
     mysql2 (0.5.6)
-    net-imap (0.5.2)
+    net-imap (0.5.4)
       date
       net-protocol
     net-pop (0.1.2)

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.13.0"
+    VERSION = "2.13.1"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",


### PR DESCRIPTION
In the previous PR we introduced `.with_through_id_relationship` to make through relatioship queries contextually more efficient. There was however, a weakness where a nested through relationship or additional scopes applied to said relationship were not being accounted for. This PR adds that check. It uses the relation symbol for the 2nd level association so no looping / recursion is required. We just needed to handle the special cases where the 2nd level was an inner join and/or the 2nd level had a scope proc on it. 

An example of this in action is:

<code>SELECT `contacts`.* FROM `contacts` WHERE `contacts`.`workspace_id` = 3 AND `contacts`.`billable` = TRUE AND (`contacts`.`id` NOT IN (SELECT `contacts`.`id` FROM `contacts` INNER JOIN `orders` ON `orders`.`contact_id` = `contacts`.`id` INNER JOIN `orders_line_items` ON `orders_line_items`.`order_id` = `orders`.`id` AND `orders`.`service_status` IN ('churned', 'canceled') INNER JOIN `products` ON `products`.`id` = `orders_line_items`.`original_product_id` WHERE (`products`.`id` IN (6504, 2))))</code>

This is how a query will be constructed for a nested relationship with a scope. Below, is the same blueprint made more efficient by this change

<code>SELECT `contacts`.* FROM `contacts` WHERE `contacts`.`workspace_id` = 3 AND `contacts`.`billable` = TRUE AND (`contacts`.`id` NOT IN (SELECT `orders`.`contact_id` FROM `orders` INNER JOIN `orders_line_items` ON `orders_line_items`.`order_id` = `orders`.`id` WHERE `orders`.`service_status` IN ('churned', 'canceled') AND (`orders_line_items`.`original_product_id` IN (6504, 2))))</code>