### PR TITLE
adding special handling for belongs_to in through_id_relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.13.3
+  * Patch for through relationship efficiency with associations with belongs_to
 ### 2.13.2
   * Disable Turbo link prefetch for advanced inline UI
 ### 2.13.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.13.2)
+    refine-rails (2.13.3)
       rails (>= 6.0)
 
 GEM

--- a/app/models/refine/conditions/uses_attributes.rb
+++ b/app/models/refine/conditions/uses_attributes.rb
@@ -127,6 +127,9 @@ module Refine::Conditions
       if self.through_id_relationship
         if instance.is_a? ActiveRecord::Reflection::ThroughReflection
           through_reflection = instance.through_reflection
+          if(through_reflection.is_a?(ActiveRecord::Reflection::BelongsToReflection))
+            through_reflection = instance.source_reflection.through_reflection
+          end
           parent_foreign_key = through_reflection.foreign_key
           child_foreign_key = instance.source_reflection.foreign_key
           relation_table_being_queried = through_reflection.klass.arel_table

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.13.2"
+    VERSION = "2.13.3"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",

--- a/test/refine/models/conditions/complex_associations/has_many_through_complex_test.rb
+++ b/test/refine/models/conditions/complex_associations/has_many_through_complex_test.rb
@@ -1,0 +1,126 @@
+require "test_helper"
+require "support/refine/filter_test_helper"
+
+module Refine::Conditions::ComplexAssociations
+  describe "Has Many Through ComplexTest" do
+    include FilterTestHelper
+
+    around do |test|
+      ApplicationRecord.connection.execute("CREATE TABLE products (id bigint primary key);")
+      ApplicationRecord.connection.execute("CREATE TABLE products_variants (id bigint primary key, product_id bigint);")
+      ApplicationRecord.connection.execute("CREATE TABLE orders (id bigint primary key, contact_id bigint, service_status varchar(255));")
+      ApplicationRecord.connection.execute("CREATE TABLE orders_line_items (id bigint primary key, order_id bigint, original_product_id bigint);")
+      ApplicationRecord.connection.execute("CREATE TABLE orders_transactions (id bigint primary key, order_id bigint);")
+      test.call
+      ApplicationRecord.connection.execute("DROP TABLE products, orders, orders_line_items, orders_transactions, products_variants;")
+    end
+
+
+    it "properly handles negative option conditions with through id set on a nested relationship" do 
+      # TODO 
+      query = create_nested_through_products(does_not_contain_option_condition_nested)
+      expected_sql = <<~SQL.squish
+      SELECT
+        `orders_transactions`.*
+      FROM
+        `orders_transactions`
+      WHERE (`orders_transactions`.`id` NOT IN (SELECT 
+            `orders_line_items`.`order_id` FROM `orders_line_items`
+          WHERE (`orders_line_items`.`original_product_id` IN (2, 6505))))
+      SQL
+      assert_equal convert(expected_sql), query.get_query.to_sql
+    end
+
+    it "properly handles positive option conditions with through id set on a nested relationship" do 
+      # TODO 
+      query = create_nested_through_variants(contain_option_condition_nested)
+      expected_sql = <<~SQL.squish
+      SELECT
+        `orders_transactions`.*
+      FROM
+        `orders_transactions`
+      WHERE (`orders_transactions`.`id` IN (SELECT 
+            `orders_line_items`.`order_id` FROM `orders_line_items`
+          WHERE (`orders_line_items`.`variant_id` IN ('4', '505'))))
+      SQL
+      assert_equal convert(expected_sql), query.get_query.to_sql
+    end
+
+    def does_not_contain_option_condition_nested
+      Refine::Blueprints::Blueprint.new
+        .criterion("products.id",
+          clause: Refine::Conditions::OptionCondition::CLAUSE_NOT_IN,
+          selected: ["6505", "2"])
+    end
+
+    def contain_option_condition_nested
+      Refine::Blueprints::Blueprint.new
+        .criterion("purchased_variants.id",
+          clause: Refine::Conditions::OptionCondition::CLAUSE_IN,
+          selected: ["505", "4"])
+    end
+
+    def create_nested_through_products(blueprint)
+      BlankTestFilter.new(blueprint,
+        Orders::Transaction.all,
+        [
+          Refine::Conditions::OptionCondition.new("products.id").with_options([{id: "2", display: "Option 2"}, {id: "6505", display: "Option 6505"}]).with_through_id_relationship
+        ],
+        Orders::Transaction.arel_table) 
+    end
+    
+    def create_nested_through_variants(blueprint)
+      BlankTestFilter.new(blueprint,
+        Orders::Transaction.all,
+        [
+          Refine::Conditions::OptionCondition.new("purchased_variants.id").with_options([{id: "4", display: "Option 4"}, {id: "505", display: "Option 505"}]).with_through_id_relationship
+        ],
+        Orders::Transaction.arel_table) 
+    end
+  end
+
+  class Transaction < ActiveRecord::Base
+    belongs_to :order
+    has_many :products, through: :order
+    has_many :purchased_variants, through: :order
+  end
+
+  class Order < ActiveRecord::Base
+    belongs_to :contact
+    has_many :line_items, class_name: "Refine::Conditions::ComplexAssociations::Orders::LineItem", dependent: :destroy
+    has_many :products, through: :line_items, source: :original_product
+    has_many :purchased_variants, class_name: "Refine::Conditions::ComplexAssociations::Products::Variant", through: :line_items, source: :variant
+    has_many :transactions, class_name: "Refine::Conditions::ComplexAssociations::Orders::Transaction", dependent: :destroy, foreign_key: :order_id
+  end
+
+  class Product < ActiveRecord::Base
+  end
+
+  module Products
+    def self.table_name_prefix
+      "products_"
+    end
+  end
+
+  class Products::Variant < ActiveRecord::Base
+    belongs_to :product, class_name: "Refine::Conditions::ComplexAssociations::Product", inverse_of: :variants
+  end
+
+  module Orders
+    def self.table_name_prefix
+      "orders_"
+    end
+  end
+
+  class Orders::LineItem < ActiveRecord::Base
+    belongs_to :order, class_name: "Refine::Conditions::ComplexAssociations::Order"
+    belongs_to :original_product, class_name: "Refine::Conditions::ComplexAssociations::Product"
+    belongs_to :variant, class_name: "Refine::Conditions::ComplexAssociations::Products::Variant"
+  end
+
+  class Orders::Transaction < ActiveRecord::Base
+    belongs_to :order, class_name: "Refine::Conditions::ComplexAssociations::Order"
+    has_many :products, through: :order
+    has_many :purchased_variants, through: :order
+  end
+end

--- a/test/refine/models/conditions/complex_associations/has_many_through_relationship_test.rb
+++ b/test/refine/models/conditions/complex_associations/has_many_through_relationship_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "support/refine/filter_test_helper"
 
-module Refine::Conditions
+module Refine::Conditions::ComplexAssociations
   describe "Has Many Through Test" do
     include FilterTestHelper
 
@@ -119,21 +119,21 @@ module Refine::Conditions
     def does_not_contain_option_condition
       Refine::Blueprints::Blueprint.new
         .criterion("tags.id",
-          clause: OptionCondition::CLAUSE_NOT_IN,
+          clause: Refine::Conditions::OptionCondition::CLAUSE_NOT_IN,
           selected: ["1"])
     end
 
     def does_not_contain_option_condition_nested
       Refine::Blueprints::Blueprint.new
         .criterion("churned_products.id",
-          clause: OptionCondition::CLAUSE_NOT_IN,
+          clause: Refine::Conditions::OptionCondition::CLAUSE_NOT_IN,
           selected: ["6505", "2"])
     end
 
     def contains_option_condition
       Refine::Blueprints::Blueprint.new
         .criterion("tags.id",
-          clause: OptionCondition::CLAUSE_IN,
+          clause: Refine::Conditions::OptionCondition::CLAUSE_IN,
           selected: ["1"])
     end
 
@@ -142,7 +142,7 @@ module Refine::Conditions
       BlankTestFilter.new(blueprint,
         Contact.all,
         [
-          OptionCondition.new("tags.id").with_options([{id: "1", display: "Option 1"}])
+          Refine::Conditions::OptionCondition.new("tags.id").with_options([{id: "1", display: "Option 1"}])
         ],
         Contact.arel_table)
     end
@@ -152,7 +152,7 @@ module Refine::Conditions
       BlankTestFilter.new(blueprint,
         Contact.all,
         [
-          OptionCondition.new("tags.id").with_options([{id: "1", display: "Option 1"}]).with_through_id_relationship
+          Refine::Conditions::OptionCondition.new("tags.id").with_options([{id: "1", display: "Option 1"}]).with_through_id_relationship
         ],
         Contact.arel_table)
     end
@@ -162,7 +162,7 @@ module Refine::Conditions
       BlankTestFilter.new(blueprint,
         Contact.all,
         [
-          OptionCondition.new("tags.id").with_options([{id: "1", display: "Option 1"}]).with_through_id_relationship.with_forced_index(index)
+          Refine::Conditions::OptionCondition.new("tags.id").with_options([{id: "1", display: "Option 1"}]).with_through_id_relationship.with_forced_index(index)
         ],
         Contact.arel_table)
     end
@@ -171,7 +171,7 @@ module Refine::Conditions
       BlankTestFilter.new(blueprint,
       Contact.all,
       [
-        OptionCondition.new("last_activity.last_activity_at").with_options([{id: "1", display: "Option 1"}]).with_through_id_relationship
+        Refine::Conditions::OptionCondition.new("last_activity.last_activity_at").with_options([{id: "1", display: "Option 1"}]).with_through_id_relationship
       ],
       Contact.arel_table) 
     end
@@ -180,14 +180,14 @@ module Refine::Conditions
       BlankTestFilter.new(blueprint,
         Contact.all,
         [
-          OptionCondition.new("churned_products.id").with_options([{id: "2", display: "Option 2"}, {id: "6505", display: "Option 6505"}]).with_through_id_relationship
+          Refine::Conditions::OptionCondition.new("churned_products.id").with_options([{id: "2", display: "Option 2"}, {id: "6505", display: "Option 6505"}]).with_through_id_relationship
         ],
         Contact.arel_table) 
     end
   end
 
   class Contact < ActiveRecord::Base
-    has_many :applied_tags, class_name: "Refine::Conditions::Contact::AppliedTag", dependent: :destroy
+    has_many :applied_tags, class_name: "Refine::Conditions::ComplexAssociations::Contact::AppliedTag", dependent: :destroy
     has_many :tags, through: :applied_tags
 
     has_many :orders
@@ -196,17 +196,17 @@ module Refine::Conditions
     has_many :churned_line_items, -> { where(orders: {service_status: %w[churned canceled]}) }, through: :orders, source: :line_items
     has_many :churned_products, through: :churned_line_items, source: :original_product
 
-    has_one :last_activity, class_name: "Refine::Conditions::Contact::LastActivity", dependent: :destroy
+    has_one :last_activity, class_name: "Refine::Conditions::ComplexAssociations::Contact::LastActivity", dependent: :destroy
   end
 
   class Contact::AppliedTag < ActiveRecord::Base
     belongs_to :contact, touch: true
-    belongs_to :tag, class_name: "Refine::Conditions::Contact::Tag"
+    belongs_to :tag, class_name: "Refine::Conditions::ComplexAssociations::Contact::Tag"
     self.table_name = "contacts_applied_tags"
   end
 
   class Contact::Tag < ActiveRecord::Base
-    has_many :applied_tags, class_name: "Refine::Conditions::Contact::AppliedTag", dependent: :destroy
+    has_many :applied_tags, class_name: "Refine::Conditions::ComplexAssociations::Contact::AppliedTag", dependent: :destroy
     has_many :contacts, through: :applied_tags
     self.table_name = "contacts_tags"
   end
@@ -217,7 +217,7 @@ module Refine::Conditions
 
   class Order < ActiveRecord::Base
     belongs_to :contact
-    has_many :line_items, class_name: "Refine::Conditions::Orders::LineItem", dependent: :destroy
+    has_many :line_items, class_name: "Refine::Conditions::ComplexAssociations::Orders::LineItem", dependent: :destroy
   end
 
   class Product < ActiveRecord::Base
@@ -230,7 +230,7 @@ module Refine::Conditions
   end
 
   class Orders::LineItem < ActiveRecord::Base
-    belongs_to :order, class_name: "Refine::Conditions::Order"
-    belongs_to :original_product, class_name: "Refine::Conditions::Product"
+    belongs_to :order, class_name: "Refine::Conditions::ComplexAssociations::Order"
+    belongs_to :original_product, class_name: "Refine::Conditions::ComplexAssociations::Product"
   end
 end


### PR DESCRIPTION
If an activerecord association had a belongs_to in the 2nd step of the chain the previous through_id_relationship logic would break. This handles that case