### PR TITLE
Flat Queries and Filter Inspectors v0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.13.4
+  * Intitial test version of flat_query generation logic
 ### 2.13.3
   * Patch for through relationship efficiency with associations with belongs_to
 ### 2.13.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.13.3)
+    refine-rails (2.13.4)
       rails (>= 6.0)
 
 GEM
@@ -103,14 +103,14 @@ GEM
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
     mysql2 (0.5.6)
-    net-imap (0.5.5)
+    net-imap (0.5.6)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-smtp (0.5.0)
+    net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
     nokogiri (1.13.8)

--- a/app/models/refine/conditions/condition.rb
+++ b/app/models/refine/conditions/condition.rb
@@ -13,6 +13,7 @@ module Refine::Conditions
     include HasThroughIdRelationship
     include WithForcedIndex
     include HasIcon
+    include SupportsFlatQueries
 
     attr_reader :ensurances, :before_validations, :clause, :filter
     attr_accessor :display, :id, :is_refinement, :attribute

--- a/app/models/refine/conditions/supports_flat_queries.rb
+++ b/app/models/refine/conditions/supports_flat_queries.rb
@@ -1,0 +1,143 @@
+module Refine::Conditions
+  module SupportsFlatQueries
+
+    LEFT_JOIN_CLAUSES = [
+      Refine::Conditions::Clauses::NOT_IN,
+      Refine::Conditions::Clauses::NOT_SET,
+      Refine::Conditions::Clauses::DOESNT_EQUAL,
+      Refine::Conditions::Clauses::DOESNT_CONTAIN
+    ]
+    
+    # Applies the criterion which can be a relationship condition
+    #
+    # @param [Hash] input The user's input
+    # @param [Arel::Table] table The arel_table the query is built on 
+    # @param [ActiveRecord::Relation] initial_query The base query the query is built on 
+    # @param [Bool] inverse_clause Whether to invert the clause
+    # @return [Arel::Node] 
+    def apply_flat(input, table, initial_query, inverse_clause=false)
+      table ||= filter.table
+      # Ensurance validations are checking the developer configured correctly
+      run_ensurance_validations
+      # Allow developer to modify user input
+      # TODO run_before_validate(input) -> what is this for?
+
+      run_before_validate_validations(input)
+
+      # TODO Determine right place to set the clause
+      validate_user_input(input)
+      if input.dig(:filter_refinement).present?
+
+        filter_condition = call_proc_if_callable(@filter_refinement_proc)
+        # Set the filter on the filter_condition to be the current_condition's filter
+        filter_condition.set_filter(filter)
+        filter_condition.is_refinement = true
+
+        # Applying the filter condition will modify pending relationship subqueries in place
+        filter_condition.apply(input.dig(:filter_refinement), table, initial_query)
+        input.delete(:filter_refinement)
+      end
+
+      if is_relationship_attribute?
+        return handle_flat_relational_condition(input: input, query: initial_query, inverse_clause: inverse_clause)
+      end
+      # Not a relationship attribute, apply condition normally
+      nodes = apply_condition(input, table, inverse_clause)
+      if !is_refinement && has_any_refinements?
+        refined_node = apply_refinements(input)
+        # Count refinement will return nil because it directly modified pending relationship subquery
+        nodes = nodes.and(refined_node) if refined_node
+      end
+      nodes
+    end
+
+    def handle_flat_relational_condition(input:, query:, inverse_clause:)
+      # Split on first .
+      decompose_attribute = @attribute.split(".", 2)
+      # Attribute now is the back half of the initial attribute
+      @attribute = decompose_attribute[1]
+      # Relation to be handled
+      relation = decompose_attribute[0]
+
+     
+      # Get the Reflection object which defines the relationship between query and relation
+      # First iteration pull relationship using base query which responds to model.
+      instance = if query.respond_to? :model
+        query.model.reflect_on_association(relation.to_sym)
+      else
+        # When query is sent in as subquery (recursive) the query object is the model class pulled from the
+        # previous instance value
+        query.reflect_on_association(relation.to_sym)
+      end
+
+      through_reflection = instance
+
+      # TODO - make sure we're accounting for refinements
+      if @attribute == "id"
+        # We're referencing a primary key ID, so we dont need the final join table and
+        # can just reference the foreign key of the previous step in the relation chain
+        through_reflection = get_through_reflection(instance: instance, relation: decompose_attribute[0])
+        add_pending_joins_if_needed(instance: instance, reflection: through_reflection, input: input)
+        @attribute = get_foreign_key_from_relation(instance: instance, reflection: through_reflection)
+      else
+        puts "TODO - not referencing an ID in attribute"
+      end
+
+      unless instance
+        raise "Relationship does not exist for #{relation}."
+      end
+
+      relation_table_being_queried = through_reflection.klass.arel_table
+      relation_class = through_reflection.klass
+
+      nodes = apply_condition(input, relation_table_being_queried, inverse_clause)
+      if !is_refinement && has_any_refinements?
+        refined_node = apply_refinements(input)
+        # Count refinement will return nil because it directly modified pending relationship subquery
+        nodes = nodes.and(refined_node) if refined_node
+      end
+      nodes
+
+      # if can_use_where_in_relationship_subquery?(instance)
+      #   create_pending_wherein_subquery(input: input, relation: relation, instance: instance, query: query)
+      # else
+      #   create_pending_has_many_through_subquery(input: input, relation: relation, instance: instance, query: query)
+      # end
+    end
+
+    def get_through_reflection(instance:, relation:)
+      if instance.is_a? ActiveRecord::Reflection::ThroughReflection
+        through_reflection = instance.through_reflection
+        instance.active_record_primary_key.to_sym
+        if(through_reflection.is_a?(ActiveRecord::Reflection::BelongsToReflection))
+          through_reflection = instance.source_reflection.through_reflection
+        end
+        through_reflection
+      else
+        puts "Not a through Reflection: #{instance.inspect}"
+      end
+    end
+
+    def get_foreign_key_from_relation(instance:, reflection:)
+      child_foreign_key = instance.source_reflection.foreign_key
+      child_foreign_key
+    end
+
+    def add_pending_join(relation, join_type=:inner)
+      # If we already are tracking the relation with a left joins, don't overwrite it
+      # puts "adding a pending join for relation: #{relation} with join type: #{join_type}"
+      unless join_type == :inner && filter.pending_joins[relation] == :left
+        filter.pending_joins[relation] = join_type
+      end
+    end
+
+    def add_pending_joins_if_needed(instance:, reflection:, input:)
+      # Determine if we need to do left-joins due to the clause needing to include null values
+      if(input && LEFT_JOIN_CLAUSES.include?(input[:clause]))
+        add_pending_join(reflection.name, :left)
+      else
+        add_pending_join(reflection.name, :inner)
+      end
+    end
+  end
+end

--- a/app/models/refine/filter.rb
+++ b/app/models/refine/filter.rb
@@ -5,6 +5,8 @@ module Refine
     include TracksPendingRelationshipSubqueries
     include Stabilize
     include Internationalized
+    include Inspector
+    include FlatQueryTools
     # This validation structure sents `initial_query` as the method to validate against
     define_model_callbacks :initialize, only: [:after]
     after_initialize :valid?
@@ -211,7 +213,7 @@ module Refine
 
     def apply_condition(criterion)
       begin
-        get_condition_for_criterion(criterion)&.apply(criterion[:input], table, initial_query)
+        get_condition_for_criterion(criterion)&.apply(criterion[:input], table, initial_query, false, nil)
       rescue Refine::Conditions::Errors::ConditionClauseError => e
         e.errors.each do |error|
           errors.add(:base, error.full_message, criterion_uid: criterion[:uid])

--- a/app/models/refine/flat_query_tools.rb
+++ b/app/models/refine/flat_query_tools.rb
@@ -1,0 +1,100 @@
+# This module is meant to provide an alternative to #get_query which will attempt to make the query flat with inner and left joins
+# instead of nested queries. This is useful for performance reasons when the query is complex and the database is large.
+# NOTE: This is more specialized query construction and it is up to the implementer to use the inspector tools to ensure this is only being used for supported queries
+module Refine
+  module FlatQueryTools
+    attr_accessor :pending_joins, :applied_conditions
+
+    def pending_joins
+      @pending_joins ||= {}
+    end
+
+    def applied_conditions
+      @applied_conditions ||= {}
+    end
+
+    def get_flat_query
+      raise "Initial query must exist" if initial_query.nil?
+      raise "Cannot make flat query for a filter using OR conditions" if uses_or?
+      if blueprint.present?
+        construct_flat_query
+      else
+        @relation
+      end
+    end
+
+    def get_flat_query!
+      result = get_flat_query
+      raise Refine::InvalidFilterError.new(filter: self) unless errors.none?
+      result
+    end
+
+    # This iterates through each blueprint item and applies the conditions.
+    # It is meant to be idempotent hence it checks for already applied conditions
+    def construct_flat_query
+      groups = []
+      blueprint.each do |criteria_or_conjunction|
+        if criteria_or_conjunction[:type] == "conjunction"
+          if criteria_or_conjunction[:word] == "or"
+            puts "This is an OR"
+            # Reset applied conditions since we're in a new group
+            @applied_conditions = {}
+          end
+        else
+          unless condition_already_applied?(criteria_or_conjunction)
+            node = apply_flat_condition(criteria_or_conjunction)
+            @relation = @relation.where(Arel.sql(node.to_sql))
+            track_condition_applied(criteria_or_conjunction)
+          end
+        end
+      end
+      if pending_joins.present?
+        apply_pending_joins
+      end
+      @relation
+    end
+
+    # Same as Filter.apply_condition but uses `supports_flat_queries` helpers instead of default path
+    def apply_flat_condition(criterion)
+      begin
+        get_condition_for_criterion(criterion)&.apply_flat(criterion[:input], table, initial_query, false)
+      rescue Refine::Conditions::Errors::ConditionClauseError => e
+        e.errors.each do |error|
+          errors.add(:base, error.full_message, criterion_uid: criterion[:uid])
+        end
+      end
+    end
+
+    # Called at the end of the filter's construct_flat_query. Applies joins from pending_joins hash constructed by individual conditions
+    def apply_pending_joins
+      if pending_joins.present?
+        join_count = 0
+        pending_joins.each do |relation, join_type|
+          if join_type == :left
+            @relation = @relation.left_joins(relation.to_sym).distinct
+          else
+            @relation = @relation.joins(relation.to_sym)
+          end
+          join_count += 1
+        end
+
+        if join_count > 1
+          @relation = @relation.distinct
+        end
+      end
+    end
+
+    def track_condition_applied(criterion)
+      if applied_conditions[criterion[:condition_id]].nil?
+        applied_conditions[criterion[:condition_id]] = [criterion[:input]]
+      else
+        applied_conditions[criterion[:condition_id]] << criterion[:input]
+      end
+    end
+
+    def condition_already_applied?(criterion)
+      applied_conditions[criterion[:condition_id]] && 
+        applied_conditions[criterion[:condition_id]].include?(criterion[:input])
+    end
+  end
+end

--- a/app/models/refine/inspector.rb
+++ b/app/models/refine/inspector.rb
@@ -1,0 +1,35 @@
+module Refine
+  module Inspector
+    def uses_or?
+      return false if @blueprint.nil? || @blueprint.empty?
+      @blueprint.select{|c| c[:type] == "conjunction" && c[:word] == "or"}.any?
+    end
+
+    def uses_and?
+      return false if @blueprint.nil? || @blueprint.empty?
+      @blueprint.select{|c| c[:type] == "conjunction" && c[:word] == "and"}.any?
+    end
+
+    def uses_condition(condition_id, using_clauses: [])
+      return false if @blueprint.nil? || @blueprint.empty?
+      condition = @blueprint.select{|c| c[:type] == "criterion" && c[:condition_id] == condition_id}.any?
+      using_clauses = [using_clauses] unless using_clauses&.is_a?(Array)
+      if(using_clauses.any?)
+        condition = condition && @blueprint.select{|c| c[:type] == "criterion" && using_clauses.include?(c[:input][:clause]) }.any?
+      end
+      return condition
+    end
+
+    def uses_negative_clause?
+      return false if @blueprint.nil? || @blueprint.empty?
+      negative_clauses = [
+        Refine::Conditions::Clauses::NOT_IN,
+        Refine::Conditions::Clauses::NOT_SET,
+        Refine::Conditions::Clauses::DOESNT_EQUAL,
+        Refine::Conditions::Clauses::DOESNT_CONTAIN
+      ]
+      @blueprint.select{|c| c[:type] == "criterion" && negative_clauses.include?(c[:input][:clause])}.any?
+    end
+
+  end
+end

--- a/app/models/refine/inspector.rb
+++ b/app/models/refine/inspector.rb
@@ -20,6 +20,12 @@ module Refine
       return condition
     end
 
+    def uses_condition_at_least(condition_id, occurrences: 1)
+      return false if @blueprint.nil? || @blueprint.empty?
+      conditions = @blueprint.select{|c| c[:type] == "criterion" && c[:condition_id] == condition_id}
+      return conditions.length >= occurrences
+    end
+
     def uses_negative_clause?
       return false if @blueprint.nil? || @blueprint.empty?
       negative_clauses = [

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.13.3"
+    VERSION = "2.13.4"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",

--- a/test/refine/models/filters/flat_query_tools/flat_query_tags_test.rb
+++ b/test/refine/models/filters/flat_query_tools/flat_query_tags_test.rb
@@ -1,0 +1,172 @@
+require "test_helper"
+require "support/refine/test_double_filter"
+require "support/refine/contact_complex_relationships"
+require "refine/invalid_filter_error"
+
+describe Refine::Filter do
+  include FilterTestHelper
+
+  around do |test|
+    ApplicationRecord.connection.execute("CREATE TABLE contacts (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE contacts_applied_tags (id bigint primary key, contact_id bigint, tag_id bigint);")
+    ApplicationRecord.connection.execute("CREATE TABLE contacts_tags (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE contacts_last_activities (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE products (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE orders (id bigint primary key, contact_id bigint, service_status varchar(255));")
+    ApplicationRecord.connection.execute("CREATE TABLE orders_line_items (id bigint primary key, order_id bigint, original_product_id bigint);")
+    test.call
+    ApplicationRecord.connection.execute("DROP TABLE contacts, contacts_applied_tags, contacts_tags, contacts_last_activities, products, orders, orders_line_items;")
+  end
+
+  describe "get_flat_query" do
+    it "two separaete criteria referencing tags generates a proper query" do
+      initial_query = Contact.all
+      filter = create_filter(two_tag_criteria)
+
+      expected_sql = <<-SQL.squish
+        SELECT `contacts`.* FROM `contacts` 
+          INNER JOIN `contacts_applied_tags` ON `contacts_applied_tags`.`contact_id` = `contacts`.`id` 
+          WHERE ((`contacts_applied_tags`.`tag_id` IN (1, 2))) AND ((`contacts_applied_tags`.`tag_id` = 4))
+      SQL
+      assert_equal expected_sql, filter.get_flat_query.to_sql
+    end
+    
+  end
+
+  def create_filter(blueprint=nil)
+    tag_options = [{id: "1", display: "tag1"}, {id: "2", display: "tag2"}, {id: "3", display: "tag3"}, {id: "4", display: "tag4"}]
+    BlankTestFilter.new(blueprint,
+      Contact.all,
+      [
+        Refine::Conditions::TextCondition.new("text_field_value"),
+        Refine::Conditions::OptionCondition.new("tags.id").with_options(proc { tag_options })
+      ],
+      Contact.arel_table)
+  end
+
+  def two_tag_criteria
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "tags.id",
+      input: {
+        clause: "in",
+        selected: ["1", "2"]
+      }
+    }, { # conjunction
+      depth: 0,
+      type: "conjunction",
+      word: "and"
+    }, {
+      depth: 0,
+      type: "criterion",
+      condition_id: "tags.id",
+      input: {
+        clause: "eq",
+        selected: ["4"]
+      }
+    }]
+  end
+
+  def and_condition_blueprint
+    [{ # criterion aaron and aa
+      depth: 0,
+      type: "criterion",
+      condition_id: "text_field_value",
+      input: {
+        clause: "eq",
+        value: "aaron"
+      }
+    }, { # conjunction
+      depth: 0,
+      type: "conjunction",
+      word: "and"
+    }, { # criterion
+      depth: 0,
+      type: "criterion",
+      condition_id: "text_field_value",
+      input: {
+        clause: "eq",
+        value: "aa"
+      }
+    }]
+  end
+
+  def or_condition_blueprint
+    [{ # criterion aaron OR aa
+      depth: 0,
+      type: "criterion",
+      condition_id: "text_field_value",
+      input: {
+        clause: "eq",
+        value: "aaron"
+      }
+    }, { # conjunction
+      depth: 0,
+      type: "conjunction",
+      word: "or"
+    }, { # criterion
+      depth: 0,
+      type: "criterion",
+      condition_id: "text_field_value",
+      input: {
+        clause: "eq",
+        value: "aa"
+      }
+    }]
+  end
+
+  def grouped_or_blueprint
+    [{
+      type: "criterion",
+      condition_id: "user_name",
+      depth: 1,
+      input: {
+        clause: "cont",
+        value: "Aaron"
+      }
+    },
+      {
+        type: "conjunction",
+        word: "and",
+        depth: 1
+      },
+      {
+        type: "criterion",
+        condition_id: "user_name",
+        depth: 1,
+        input: {
+          clause: "cont",
+          value: "Francis"
+        }
+      },
+      {
+        type: "conjunction",
+        word: "or",
+        depth: 0
+      },
+      {
+        type: "criterion",
+        condition_id: "user_name",
+        depth: 1,
+        input: {
+          clause: "cont",
+          value: "Sean"
+        }
+      },
+      {
+        type: "conjunction",
+        word: "and",
+        depth: 1
+      },
+      {
+        type: "criterion",
+        condition_id: "user_name",
+        depth: 1,
+        input: {
+          clause: "cont",
+          value: "Fioritto"
+        }
+      }]
+  end
+end

--- a/test/refine/models/filters/flat_query_tools_test.rb
+++ b/test/refine/models/filters/flat_query_tools_test.rb
@@ -1,0 +1,271 @@
+require "test_helper"
+require "support/refine/test_double_filter"
+require "support/refine/contact_complex_relationships"
+require "refine/invalid_filter_error"
+
+describe Refine::Filter do
+  include FilterTestHelper
+
+  around do |test|
+    ApplicationRecord.connection.execute("CREATE TABLE contacts (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE contacts_applied_tags (id bigint primary key, contact_id bigint, tag_id bigint);")
+    ApplicationRecord.connection.execute("CREATE TABLE contacts_tags (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE contacts_last_activities (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE products (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE orders (id bigint primary key, contact_id bigint, service_status varchar(255));")
+    ApplicationRecord.connection.execute("CREATE TABLE orders_line_items (id bigint primary key, order_id bigint, original_product_id bigint);")
+    test.call
+    ApplicationRecord.connection.execute("DROP TABLE contacts, contacts_applied_tags, contacts_tags, contacts_last_activities, products, orders, orders_line_items;")
+  end
+
+  describe "get_flat_query" do
+    it "raises an error if the initial query is nil" do
+      query = create_filter(single_condition_blueprint)
+      query.instance_variable_set(:@initial_query, nil)
+      assert_raises(RuntimeError) { query.get_flat_query }
+    end
+
+    it "raises an error if the filter uses OR conditions" do
+      query = create_filter(or_condition_blueprint)
+      assert_raises(RuntimeError) { query.get_flat_query } 
+    end
+
+    it "returns the relation if the blueprint is nil" do
+      initial_query = Contact.all
+      filter = create_filter
+      assert_equal filter.get_flat_query.to_sql, initial_query.to_sql
+    end
+
+    describe "with a single-condition blueprint" do
+      it "returns the relation with the condition applied" do
+        initial_query = Contact.all
+        filter = create_filter(single_tag_blueprint)
+        test_scope = initial_query.joins(:applied_tags).where(applied_tags: {tag_id: 1})
+        expected_sql = <<-SQL.squish
+          SELECT `contacts`.* FROM `contacts` 
+            INNER JOIN `contacts_applied_tags` ON `contacts_applied_tags`.`contact_id` = `contacts`.`id` 
+            WHERE ((`contacts_applied_tags`.`tag_id` = 1))
+        SQL
+        assert_equal expected_sql, filter.get_flat_query.to_sql
+      end
+
+      it "calling get_flat_query twice is idempotent" do
+        initial_query = Contact.all
+        filter = create_filter(single_tag_blueprint)
+        filter.get_flat_query
+        test_scope = initial_query.joins(:applied_tags).where(applied_tags: {tag_id: 1})
+        expected_sql = <<-SQL.squish
+          SELECT `contacts`.* FROM `contacts` 
+            INNER JOIN `contacts_applied_tags` ON `contacts_applied_tags`.`contact_id` = `contacts`.`id` 
+            WHERE ((`contacts_applied_tags`.`tag_id` = 1)) 
+        SQL
+        assert_equal  expected_sql, filter.get_flat_query.to_sql
+      end
+    end
+  end
+
+  def grouped_blueprint
+    Refine::Blueprints::Blueprint.new
+      .criterion("text_field_value",
+        clause: Refine::Conditions::TextCondition::CLAUSE_EQUALS,
+        value: "one",)
+      .and
+      .group {
+        criterion("text_field_value",
+          clause: Refine::Conditions::TextCondition::CLAUSE_EQUALS,
+          value: "two",)
+          .and
+          .criterion("text_field_value",
+            clause: Refine::Conditions::TextCondition::CLAUSE_EQUALS,
+            value: "three",)
+      }
+  end
+
+  def nested_group_blueprint
+    Refine::Blueprints::Blueprint.new
+      .criterion("text_field_value",
+        clause: Refine::Conditions::TextCondition::CLAUSE_EQUALS,
+        value: "one",)
+      .and
+      .group {
+        group {
+          criterion("text_field_value",
+            clause: Refine::Conditions::TextCondition::CLAUSE_EQUALS,
+            value: "two",)
+            .and
+            .criterion("text_field_value",
+              clause: Refine::Conditions::TextCondition::CLAUSE_EQUALS,
+              value: "three",)
+        }
+          .and
+          .criterion("text_field_value",
+            clause: Refine::Conditions::TextCondition::CLAUSE_EQUALS,
+            value: "four",)
+      }
+      .and
+      .criterion("text_field_value",
+        clause: Refine::Conditions::TextCondition::CLAUSE_EQUALS,
+        value: "five")
+  end
+
+  def create_filter(blueprint=nil)
+    BlankTestFilter.new(blueprint,
+      Contact.all,
+      [
+        Refine::Conditions::TextCondition.new("text_field_value"),
+        Refine::Conditions::OptionCondition.new("tags.id").with_options(proc { [{id: "1", display: "tag1"}] })
+      ],
+      Contact.arel_table)
+  end
+
+
+  def bad_id
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "fake",
+      input: {
+        clause: "eq",
+        value: "aaron"
+      }
+    }]
+  end
+
+  def single_tag_blueprint
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "tags.id",
+      input: {
+        clause: "eq",
+        selected: ["1"]
+      }
+    }]
+  end
+
+  def single_condition_blueprint
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "text_field_value",
+      input: {
+        clause: "eq",
+        value: "aaron"
+      }
+    }]
+  end
+
+  def invalid_condition_blueprint
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "invalid_condition",
+      input: {
+        clause: "eq",
+        value: "invalid"
+      }
+    }]
+  end
+
+  def and_condition_blueprint
+    [{ # criterion aaron and aa
+      depth: 0,
+      type: "criterion",
+      condition_id: "text_field_value",
+      input: {
+        clause: "eq",
+        value: "aaron"
+      }
+    }, { # conjunction
+      depth: 0,
+      type: "conjunction",
+      word: "and"
+    }, { # criterion
+      depth: 0,
+      type: "criterion",
+      condition_id: "text_field_value",
+      input: {
+        clause: "eq",
+        value: "aa"
+      }
+    }]
+  end
+
+  def or_condition_blueprint
+    [{ # criterion aaron OR aa
+      depth: 0,
+      type: "criterion",
+      condition_id: "text_field_value",
+      input: {
+        clause: "eq",
+        value: "aaron"
+      }
+    }, { # conjunction
+      depth: 0,
+      type: "conjunction",
+      word: "or"
+    }, { # criterion
+      depth: 0,
+      type: "criterion",
+      condition_id: "text_field_value",
+      input: {
+        clause: "eq",
+        value: "aa"
+      }
+    }]
+  end
+
+  def grouped_or_blueprint
+    [{
+      type: "criterion",
+      condition_id: "user_name",
+      depth: 1,
+      input: {
+        clause: "cont",
+        value: "Aaron"
+      }
+    },
+      {
+        type: "conjunction",
+        word: "and",
+        depth: 1
+      },
+      {
+        type: "criterion",
+        condition_id: "user_name",
+        depth: 1,
+        input: {
+          clause: "cont",
+          value: "Francis"
+        }
+      },
+      {
+        type: "conjunction",
+        word: "or",
+        depth: 0
+      },
+      {
+        type: "criterion",
+        condition_id: "user_name",
+        depth: 1,
+        input: {
+          clause: "cont",
+          value: "Sean"
+        }
+      },
+      {
+        type: "conjunction",
+        word: "and",
+        depth: 1
+      },
+      {
+        type: "criterion",
+        condition_id: "user_name",
+        depth: 1,
+        input: {
+          clause: "cont",
+          value: "Fioritto"
+        }
+      }]
+  end
+end

--- a/test/refine/models/filters/inspector_test.rb
+++ b/test/refine/models/filters/inspector_test.rb
@@ -117,6 +117,48 @@ describe Refine::Filter do
     end
   end
 
+  describe "uses_condition_at_least" do
+    it "returns false if the blueprint is nil" do
+      query = create_filter
+      assert_equal query.uses_condition_at_least("text_field_value"), false
+    end
+
+    it "returns false if the blueprint is empty" do
+      query = create_filter([])
+      assert_equal query.uses_condition_at_least("text_field_value"), false
+    end
+
+    it "returns true if the condition is in use in the blueprint" do
+      query = create_filter(single_condition_blueprint)
+      assert_equal query.uses_condition_at_least("text_field_value"), true
+    end
+
+    it "returns false if the condition is not in use in the blueprint" do
+      query = create_filter(single_condition_blueprint)
+      assert_equal query.uses_condition_at_least("fake"), false
+    end
+
+    it "returns true if the condition is in use in the blueprint the specified number of times" do
+      query = create_filter(single_condition_blueprint + single_condition_blueprint)
+      assert_equal query.uses_condition_at_least("text_field_value", occurrences: 2), true
+    end
+
+    it "returns false if the condition is in use in the blueprint fewer times than specified" do
+      query = create_filter(single_condition_blueprint)
+      assert_equal query.uses_condition_at_least("text_field_value", occurrences: 2), false
+    end
+
+    it "returns true if the condition is in use in the blueprint the specified number of times with the specified clause" do
+      query = create_filter(single_condition_blueprint + single_condition_blueprint)
+      assert_equal query.uses_condition_at_least("text_field_value", occurrences: 2), true
+    end
+
+    it "returns false if the condition is in use in the blueprint fewer times than specified with the specified clause" do
+      query = create_filter(single_condition_blueprint)
+      assert_equal query.uses_condition_at_least("text_field_value", occurrences: 2), false
+    end
+  end
+
   describe "uses_negative_clause?" do
     it "returns false if the blueprint is nil" do
       query = create_filter

--- a/test/refine/models/filters/inspector_test.rb
+++ b/test/refine/models/filters/inspector_test.rb
@@ -1,0 +1,390 @@
+require "test_helper"
+require "support/refine/test_double_filter"
+require "refine/invalid_filter_error"
+
+describe Refine::Filter do
+  include FilterTestHelper
+
+  around do |test|
+    ApplicationRecord.connection.execute("CREATE TABLE t (test_bool boolean);")
+    test.call
+    ApplicationRecord.connection.execute("DROP TABLE t;")
+  end
+
+  describe "uses_or?" do
+    it "returns false if the blueprint is nil" do
+      query = create_filter
+      assert_equal query.uses_or?, false
+    end
+
+    it "returns false if the blueprint is empty" do
+      query = create_filter([])
+      assert_equal query.uses_or?, false
+    end
+
+    it "returns false for a single condition blueprint" do
+      query = create_filter(single_condition_blueprint)
+      assert_equal query.uses_or?, false
+    end
+
+    it "returns false for a mutli-condition blueprint of only ANDs" do
+      query = create_filter(and_condition_blueprint)
+      assert_equal query.uses_or?, false
+    end
+
+    it "returns true for a multi-condition blueprint with an OR" do
+      query = create_filter(or_condition_blueprint)
+      assert_equal query.uses_or?, true
+    end
+
+    it "returns true for a multi-condition AND and OR blueprint" do
+      query = create_filter(grouped_or_blueprint)
+      assert_equal query.uses_or?, true
+    end
+  end
+
+  describe "uses_and?" do
+    it "returns false if the blueprint is nil" do
+      query = create_filter
+      assert_equal query.uses_and?, false
+    end
+
+    it "returns false if the blueprint is empty" do
+      query = create_filter([])
+      assert_equal query.uses_and?, false
+    end
+
+    it "returns false for a single condition blueprint" do
+      query = create_filter(single_condition_blueprint)
+      assert_equal query.uses_and?, false
+    end
+
+    it "returns true for a mutli-condition blueprint of only ANDs" do
+      query = create_filter(and_condition_blueprint)
+      assert_equal query.uses_and?, true
+    end
+
+    it "returns false for a multi-condition blueprint with an OR" do
+      query = create_filter(or_condition_blueprint)
+      assert_equal query.uses_and?, false
+    end
+
+    it "returns true for a multi-condition AND and OR blueprint" do
+      query = create_filter(grouped_or_blueprint)
+      assert_equal query.uses_and?, true
+    end
+  end
+
+  describe "uses_condition" do
+    it "returns false if the blueprint is nil" do
+      query = create_filter
+      assert_equal query.uses_condition("text_field_value"), false
+    end
+
+    it "returns false if the blueprint is empty" do
+      query = create_filter([])
+      assert_equal query.uses_condition("text_field_value"), false
+    end
+
+    it "returns true if the condition is in use in the blueprint" do
+      query = create_filter(single_condition_blueprint)
+      assert_equal query.uses_condition("text_field_value"), true
+    end
+
+    it "returns false if the condition is not in use in the blueprint" do
+      query = create_filter(single_condition_blueprint)
+      assert_equal query.uses_condition("fake"), false
+    end
+
+    it "returns true if the condition is in use in the blueprint with the supplied clause" do
+      query = create_filter(single_condition_blueprint)
+      assert_equal query.uses_condition("text_field_value", using_clauses: "eq"), true
+    end
+    
+    it "returns true if the condition is in use in the blueprint with one of the included clauses" do
+      query = create_filter(single_condition_blueprint)
+      assert_equal query.uses_condition("text_field_value", using_clauses: ["eq", "cont"]), true
+    end
+
+    it "returns false if the condition is in use in the blueprint without the clause" do
+      query = create_filter(single_condition_blueprint)
+      assert_equal query.uses_condition("text_field_value", using_clauses: "cont"), false
+    end
+
+    it "returns false if the condition is in use in the blueprint without one of the included clauses" do
+      query = create_filter(single_condition_blueprint)
+      assert_equal query.uses_condition("text_field_value", using_clauses: ["cont", "gt"]), false
+    end
+  end
+
+  describe "uses_negative_clause?" do
+    it "returns false if the blueprint is nil" do
+      query = create_filter
+      assert_equal query.uses_negative_clause?, false
+    end
+
+    it "returns false if the blueprint is empty" do
+      query = create_filter([])
+      assert_equal query.uses_negative_clause?, false
+    end
+
+    it "returns true if the blueprint contains a negative clause" do
+      query = create_filter(single_condition_blueprint)
+      assert_equal query.uses_negative_clause?, false
+    end
+
+    it "returns false if the blueprint does not contain a negative clause" do
+      query = create_filter(invalid_condition_blueprint)
+      assert_equal query.uses_negative_clause?, false
+    end
+
+    it "returns true if the blueprint contains a negative clause" do
+      query = create_filter(grouped_or_blueprint_negative)
+      assert_equal query.uses_negative_clause?, true
+    end
+  end
+
+  def grouped_blueprint
+    Refine::Blueprints::Blueprint.new
+      .criterion("text_field_value",
+        clause: Refine::Conditions::TextCondition::CLAUSE_EQUALS,
+        value: "one",)
+      .and
+      .group {
+        criterion("text_field_value",
+          clause: Refine::Conditions::TextCondition::CLAUSE_EQUALS,
+          value: "two",)
+          .and
+          .criterion("text_field_value",
+            clause: Refine::Conditions::TextCondition::CLAUSE_EQUALS,
+            value: "three",)
+      }
+  end
+
+  def nested_group_blueprint
+    Refine::Blueprints::Blueprint.new
+      .criterion("text_field_value",
+        clause: Refine::Conditions::TextCondition::CLAUSE_EQUALS,
+        value: "one",)
+      .and
+      .group {
+        group {
+          criterion("text_field_value",
+            clause: Refine::Conditions::TextCondition::CLAUSE_EQUALS,
+            value: "two",)
+            .and
+            .criterion("text_field_value",
+              clause: Refine::Conditions::TextCondition::CLAUSE_EQUALS,
+              value: "three",)
+        }
+          .and
+          .criterion("text_field_value",
+            clause: Refine::Conditions::TextCondition::CLAUSE_EQUALS,
+            value: "four",)
+      }
+      .and
+      .criterion("text_field_value",
+        clause: Refine::Conditions::TextCondition::CLAUSE_EQUALS,
+        value: "five")
+  end
+
+  def create_filter(blueprint=nil)
+    BlankTestFilter.new(blueprint,
+      FilterTestHelper::TestDouble.all,
+      [Refine::Conditions::TextCondition.new("text_field_value")],
+      FilterTestHelper::TestDouble.arel_table)
+  end
+
+
+  def bad_id
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "fake",
+      input: {
+        clause: "eq",
+        value: "aaron"
+      }
+    }]
+  end
+
+  def single_condition_blueprint
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "text_field_value",
+      input: {
+        clause: "eq",
+        value: "aaron"
+      }
+    }]
+  end
+
+  def invalid_condition_blueprint
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "invalid_condition",
+      input: {
+        clause: "eq",
+        value: "invalid"
+      }
+    }]
+  end
+
+  def and_condition_blueprint
+    [{ # criterion aaron and aa
+      depth: 0,
+      type: "criterion",
+      condition_id: "text_field_value",
+      input: {
+        clause: "eq",
+        value: "aaron"
+      }
+    }, { # conjunction
+      depth: 0,
+      type: "conjunction",
+      word: "and"
+    }, { # criterion
+      depth: 0,
+      type: "criterion",
+      condition_id: "text_field_value",
+      input: {
+        clause: "eq",
+        value: "aa"
+      }
+    }]
+  end
+
+  def or_condition_blueprint
+    [{ # criterion aaron OR aa
+      depth: 0,
+      type: "criterion",
+      condition_id: "text_field_value",
+      input: {
+        clause: "eq",
+        value: "aaron"
+      }
+    }, { # conjunction
+      depth: 0,
+      type: "conjunction",
+      word: "or"
+    }, { # criterion
+      depth: 0,
+      type: "criterion",
+      condition_id: "text_field_value",
+      input: {
+        clause: "eq",
+        value: "aa"
+      }
+    }]
+  end
+
+  def grouped_or_blueprint
+    [{
+      type: "criterion",
+      condition_id: "user_name",
+      depth: 1,
+      input: {
+        clause: "cont",
+        value: "Aaron"
+      }
+    },
+      {
+        type: "conjunction",
+        word: "and",
+        depth: 1
+      },
+      {
+        type: "criterion",
+        condition_id: "user_name",
+        depth: 1,
+        input: {
+          clause: "cont",
+          value: "Francis"
+        }
+      },
+      {
+        type: "conjunction",
+        word: "or",
+        depth: 0
+      },
+      {
+        type: "criterion",
+        condition_id: "user_name",
+        depth: 1,
+        input: {
+          clause: "cont",
+          value: "Sean"
+        }
+      },
+      {
+        type: "conjunction",
+        word: "and",
+        depth: 1
+      },
+      {
+        type: "criterion",
+        condition_id: "user_name",
+        depth: 1,
+        input: {
+          clause: "cont",
+          value: "Fioritto"
+        }
+      }]
+  end
+
+  def grouped_or_blueprint_negative
+    [{
+      type: "criterion",
+      condition_id: "user_name",
+      depth: 1,
+      input: {
+        clause: "cont",
+        value: "Aaron"
+      }
+    },
+      {
+        type: "conjunction",
+        word: "and",
+        depth: 1
+      },
+      {
+        type: "criterion",
+        condition_id: "user_name",
+        depth: 1,
+        input: {
+          clause: "dcont",
+          value: "Francis"
+        }
+      },
+      {
+        type: "conjunction",
+        word: "or",
+        depth: 0
+      },
+      {
+        type: "criterion",
+        condition_id: "user_name",
+        depth: 1,
+        input: {
+          clause: "cont",
+          value: "Sean"
+        }
+      },
+      {
+        type: "conjunction",
+        word: "and",
+        depth: 1
+      },
+      {
+        type: "criterion",
+        condition_id: "user_name",
+        depth: 1,
+        input: {
+          clause: "cont",
+          value: "Fioritto"
+        }
+      }]
+  end
+end

--- a/test/support/refine/contact_complex_relationships.rb
+++ b/test/support/refine/contact_complex_relationships.rb
@@ -1,0 +1,53 @@
+# Complex Relationship definitions for Filter Condition test and Filter Refinement test
+class Contact < ActiveRecord::Base
+  has_many :applied_tags, class_name: "Contacts::AppliedTag", dependent: :destroy
+  has_many :tags, through: :applied_tags
+
+  has_many :orders
+  has_many :line_items, through: :orders
+  has_many :products, through: :line_items, source: :original_product
+  has_many :churned_line_items, -> { where(orders: {service_status: %w[churned canceled]}) }, through: :orders, source: :line_items
+  has_many :churned_products, through: :churned_line_items, source: :original_product
+
+  has_one :last_activity, class_name: "Contacts::LastActivity", dependent: :destroy
+end
+
+module Contacts
+  def self.table_name_prefix
+    "contacts_"
+  end
+end
+
+class Contacts::AppliedTag < ActiveRecord::Base
+  belongs_to :contact, touch: true
+  belongs_to :tag, class_name: "Tag"
+end
+
+class Contacts::Tag < ActiveRecord::Base
+  has_many :applied_tags, class_name: "AppliedTag", dependent: :destroy
+  has_many :contacts, through: :applied_tags
+end
+
+class Contacts::LastActivity < ActiveRecord::Base
+  belongs_to :contact, touch: true, optional: true
+end
+
+
+class Order < ActiveRecord::Base
+  belongs_to :contact
+  has_many :line_items, class_name: "LineItem", dependent: :destroy
+end
+
+class Product < ActiveRecord::Base
+end
+
+module Orders
+  def self.table_name_prefix
+    "orders_"
+  end
+end
+
+class Orders::LineItem < ActiveRecord::Base
+  belongs_to :order, class_name: "Order"
+  belongs_to :original_product, class_name: "Product"
+end


### PR DESCRIPTION
first pass at a flat-query method of constructing filters. Meant for more performance on simpler relational attributes

* Adds an inspector module - allows users to run if conditionals on if certain things are being set up in the filter. If the end user has an OR grouping, then `uses_or?` will return true. This is helpful for determining whether to use flat queries, or perhaps know when to offload a long running query.
* Adds a flat_query module - this allows an implementer to tell refine to try to flatten queries. For this PR it only supports AND conjunctions and positive clauses. Things requiring a left joins or an OR condition are not currently supported.

