### PR TITLE
ensuring flat queries work for multi-db associations. Also adding mocha to test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.13.6
+  * Adds flat_query support for multi-db associations
 ### 2.13.5
   * Adds distinct to flat_queries that use inner_joins
 ### 2.13.4

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :development, :test do
   gem "minitest-around"
   gem "minitest-ci"
   gem "standard"
+  gem "mocha"
 end
 
 # Start debugger with binding.b [https://github.com/ruby/debug]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.13.5)
+    refine-rails (2.13.6)
       rails (>= 6.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
       minitest (~> 5.0)
     minitest-ci (3.4.0)
       minitest (>= 5.0.6)
+    mocha (2.7.1)
+      ruby2_keywords (>= 0.0.5)
     mysql2 (0.5.6)
     net-imap (0.5.6)
       date
@@ -169,6 +171,7 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -197,6 +200,7 @@ DEPENDENCIES
   byebug
   minitest-around
   minitest-ci
+  mocha
   mysql2 (~> 0.5.6)
   refine-rails!
   sprockets-rails

--- a/app/models/refine/conditions/uses_attributes.rb
+++ b/app/models/refine/conditions/uses_attributes.rb
@@ -21,13 +21,7 @@ module Refine::Conditions
 
       # Get the Reflection object which defines the relationship between query and relation
       # First iteration pull relationship using base query which responds to model.
-      instance = if query.respond_to? :model
-        query.model.reflect_on_association(relation.to_sym)
-      else
-        # When query is sent in as subquery (recursive) the query object is the model class pulled from the
-        # previous instance value
-        query.reflect_on_association(relation.to_sym)
-      end
+      instance = get_reflection_object(query, relation)
 
       unless instance
         raise "Relationship does not exist for #{relation}."
@@ -66,6 +60,16 @@ module Refine::Conditions
         instance.active_record_primary_key.to_sym
       else
         instance.foreign_key.to_sym
+      end
+    end
+
+    def get_reflection_object(query, relation)
+      if query.respond_to? :model
+        query.model.reflect_on_association(relation.to_sym)
+      else
+        # When query is sent in as subquery (recursive) the query object is the model class pulled from the
+        # previous instance value
+        query.reflect_on_association(relation.to_sym)
       end
     end
 

--- a/app/models/refine/inspector.rb
+++ b/app/models/refine/inspector.rb
@@ -37,7 +37,7 @@ module Refine
       @blueprint.select{|c| c[:type] == "criterion" && negative_clauses.include?(c[:input][:clause])}.any?
     end
 
-    def has_duplicate_conditions
+    def has_duplicate_conditions?
       return false if @blueprint.nil? || @blueprint.empty?
       conditions = @blueprint.select{|c| c[:type] == "criterion"}
       condition_ids = conditions.map{|c| c[:condition_id]}

--- a/app/models/refine/inspector.rb
+++ b/app/models/refine/inspector.rb
@@ -37,5 +37,12 @@ module Refine
       @blueprint.select{|c| c[:type] == "criterion" && negative_clauses.include?(c[:input][:clause])}.any?
     end
 
+    def has_duplicate_conditions
+      return false if @blueprint.nil? || @blueprint.empty?
+      conditions = @blueprint.select{|c| c[:type] == "criterion"}
+      condition_ids = conditions.map{|c| c[:condition_id]}
+      condition_ids.length != condition_ids.uniq.length
+    end
+
   end
 end

--- a/app/models/refine/tracks_pending_relationship_subqueries.rb
+++ b/app/models/refine/tracks_pending_relationship_subqueries.rb
@@ -116,6 +116,7 @@ module Refine
       subset.each do |relation, subquery|
         # relation = table
         # subquery.keys = [:instance, :query, :key, :secondary] possibly (:children)
+
         if subquery.dig(:children).present?
           # Send in the values at children as the subset hash and remove from existing subquery
           child_nodes = subquery.delete(:children)

--- a/app/views/refine/advanced_inline/criteria/new.turbo_stream.erb
+++ b/app/views/refine/advanced_inline/criteria/new.turbo_stream.erb
@@ -1,6 +1,5 @@
 <% form_id = dom_id(@criterion, :form) %>
 
-<% puts "In New Turbo Stream" %>
 <%= turbo_stream.update dom_id(@criterion) do %>
   <%= render "refine/advanced_inline/filters/popup",
     frame_id: dom_id(@criterion), is_open: true do

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.13.5"
+    VERSION = "2.13.6"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.13.5",
+  "version": "2.13.6",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",

--- a/test/refine/models/filters/flat_query_tools/flat_query_cross_db_test.rb
+++ b/test/refine/models/filters/flat_query_tools/flat_query_cross_db_test.rb
@@ -1,0 +1,140 @@
+require "test_helper"
+require "support/refine/test_double_filter"
+require "support/refine/contact_complex_relationships"
+require "refine/invalid_filter_error"
+require 'minitest/autorun'
+require 'mocha/minitest'
+
+describe Refine::Filter do
+  include FilterTestHelper
+
+  around do |test|
+    ApplicationRecord.connection.execute("CREATE TABLE contacts (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE contacts_applied_tags (id bigint primary key, contact_id bigint, tag_id bigint);")
+    ApplicationRecord.connection.execute("CREATE TABLE contacts_tags (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE contacts_last_activities (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE products (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE orders (id bigint primary key, contact_id bigint, service_status varchar(255));")
+    ApplicationRecord.connection.execute("CREATE TABLE orders_line_items (id bigint primary key, order_id bigint, original_product_id bigint);")
+    ApplicationRecord.connection.execute("CREATE TABLE events (id bigint primary key auto_increment, source_id bigint, contact_id bigint);")
+    test.call
+    ApplicationRecord.connection.execute("DROP TABLE contacts, contacts_applied_tags, contacts_tags, contacts_last_activities, products, orders, orders_line_items, events;")
+  end
+
+  describe "get_flat_query with a cross-db lookup" do
+    it "properly constructs the initial query before applying the condition" do
+      initial_query = Contact.all
+      filter = create_filter(event_blueprint)
+      Refine::Conditions::Condition.any_instance.stubs(:condiiton_uses_different_database?).returns(true)
+      executed_queries = []
+      original_execute = Event.connection.method(:execute)
+
+      expected_event_sql = <<-SQL.squish
+        SELECT `events`.`contact_id` FROM `events`
+          WHERE (`events`.`source_id` IN (1, 2))
+      SQL
+
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |name, start, finish, id, payload|
+        executed_queries << payload[:sql]
+      end
+
+      filter.get_flat_query
+
+      assert executed_queries.any? { |sql| sql.include?(expected_event_sql)  }, "Expected to find the event query in the executed queries: #{expected_event_sql}"
+
+    end
+
+    it "single check " do
+      initial_query = Contact.all
+      Event.create(source_id: 1, contact_id: 50)
+      filter = create_filter(event_blueprint)
+      Refine::Conditions::Condition.any_instance.stubs(:condiiton_uses_different_database?).returns(true)
+
+      expected_sql = <<-SQL.squish
+        SELECT `contacts`.* FROM `contacts` 
+          WHERE (`contacts`.`id` = 50)
+      SQL
+      assert_equal expected_sql, filter.get_flat_query.to_sql
+    end
+
+    it "multi-result check" do
+      initial_query = Contact.all
+      Event.create(source_id: 1, contact_id: 50)
+      Event.create(source_id: 1, contact_id: 51)
+      filter = create_filter(event_blueprint)
+      Refine::Conditions::Condition.any_instance.stubs(:condiiton_uses_different_database?).returns(true)
+
+      expected_sql = <<-SQL.squish
+        SELECT `contacts`.* FROM `contacts` 
+          WHERE (`contacts`.`id` IN (50, 51))
+      SQL
+      assert_equal expected_sql, filter.get_flat_query.to_sql    
+    end
+
+    it "multi-condition check" do
+      initial_query = Contact.all
+      Event.create(source_id: 1, contact_id: 50)
+      Event.create(source_id: 2, contact_id: 51)
+      Event.create(source_id: 5, contact_id: 50)
+      filter = create_filter(multi_event_blueprint)
+      Refine::Conditions::Condition.any_instance.stubs(:condiiton_uses_different_database?).returns(true)
+
+      expected_sql = <<-SQL.squish
+        SELECT `contacts`.* FROM `contacts` 
+          WHERE (`contacts`.`id` IN (50, 51)) AND (`contacts`.`id` = 50)
+      SQL
+      assert_equal expected_sql, filter.get_flat_query.to_sql     
+    end
+    
+  end
+
+  def create_filter(blueprint=nil)
+    tag_options = [{id: "1", display: "tag1"}, {id: "2", display: "tag2"}, {id: "3", display: "tag3"}, {id: "4", display: "tag4"}]
+    event_source_options = [{id: "1", display: "source1"}, {id: "2", display: "source2"}, {id: "5", display: "source5"}]
+    BlankTestFilter.new(blueprint,
+      Contact.all,
+      [
+        Refine::Conditions::TextCondition.new("text_field_value"),
+        Refine::Conditions::OptionCondition.new("tags.id").with_options(proc { tag_options }),
+        Refine::Conditions::OptionCondition.new("events.source_id").with_options(proc { event_source_options })
+      ],
+      Contact.arel_table)
+  end
+
+  def event_blueprint
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "events.source_id",
+      input: {
+        clause: "in",
+        selected: ["1", "2"]
+      }
+    }]
+  end
+
+  def multi_event_blueprint
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "events.source_id",
+      input: {
+        clause: "in",
+        selected: ["1", "2"]
+      }
+    }, {
+      depth: 0,
+      type: "conjunction",
+      word: "and"
+    }, {
+      depth: 0,
+      type: "criterion",
+      condition_id: "events.source_id",
+      input: {
+        clause: "eq",
+        selected: ["5"]
+      }
+    }]
+  end
+
+end

--- a/test/refine/models/filters/flat_query_tools_test.rb
+++ b/test/refine/models/filters/flat_query_tools_test.rb
@@ -40,7 +40,6 @@ describe Refine::Filter do
       it "returns the relation with the condition applied" do
         initial_query = Contact.all
         filter = create_filter(single_tag_blueprint)
-        test_scope = initial_query.joins(:applied_tags).where(applied_tags: {tag_id: 1})
         expected_sql = <<-SQL.squish
           SELECT DISTINCT `contacts`.* FROM `contacts` 
             INNER JOIN `contacts_applied_tags` ON `contacts_applied_tags`.`contact_id` = `contacts`.`id` 
@@ -53,7 +52,6 @@ describe Refine::Filter do
         initial_query = Contact.all
         filter = create_filter(single_tag_blueprint)
         filter.get_flat_query
-        test_scope = initial_query.joins(:applied_tags).where(applied_tags: {tag_id: 1})
         expected_sql = <<-SQL.squish
           SELECT DISTINCT `contacts`.* FROM `contacts` 
             INNER JOIN `contacts_applied_tags` ON `contacts_applied_tags`.`contact_id` = `contacts`.`id` 

--- a/test/refine/models/filters/inspector_test.rb
+++ b/test/refine/models/filters/inspector_test.rb
@@ -189,22 +189,22 @@ describe Refine::Filter do
   describe "has_duplicate_conditions" do
     it "returns false if the blueprint is nil" do
       query = create_filter
-      assert_equal query.has_duplicate_conditions, false
+      assert_equal query.has_duplicate_conditions?, false
     end
 
     it "returns false if the blueprint is empty" do
       query = create_filter([])
-      assert_equal query.has_duplicate_conditions, false
+      assert_equal query.has_duplicate_conditions?, false
     end
 
     it "returns false if the blueprint does not contain duplicate conditions" do
       query = create_filter(single_condition_blueprint)
-      assert_equal query.has_duplicate_conditions, false
+      assert_equal query.has_duplicate_conditions?, false
     end
 
     it "returns true if the blueprint contains duplicate conditions" do
       query = create_filter(and_condition_blueprint)
-      assert_equal query.has_duplicate_conditions, true
+      assert_equal query.has_duplicate_conditions?, true
     end
   end
 

--- a/test/refine/models/filters/inspector_test.rb
+++ b/test/refine/models/filters/inspector_test.rb
@@ -186,6 +186,28 @@ describe Refine::Filter do
     end
   end
 
+  describe "has_duplicate_conditions" do
+    it "returns false if the blueprint is nil" do
+      query = create_filter
+      assert_equal query.has_duplicate_conditions, false
+    end
+
+    it "returns false if the blueprint is empty" do
+      query = create_filter([])
+      assert_equal query.has_duplicate_conditions, false
+    end
+
+    it "returns false if the blueprint does not contain duplicate conditions" do
+      query = create_filter(single_condition_blueprint)
+      assert_equal query.has_duplicate_conditions, false
+    end
+
+    it "returns true if the blueprint contains duplicate conditions" do
+      query = create_filter(and_condition_blueprint)
+      assert_equal query.has_duplicate_conditions, true
+    end
+  end
+
   def grouped_blueprint
     Refine::Blueprints::Blueprint.new
       .criterion("text_field_value",

--- a/test/support/refine/contact_complex_relationships.rb
+++ b/test/support/refine/contact_complex_relationships.rb
@@ -9,6 +9,8 @@ class Contact < ActiveRecord::Base
   has_many :churned_line_items, -> { where(orders: {service_status: %w[churned canceled]}) }, through: :orders, source: :line_items
   has_many :churned_products, through: :churned_line_items, source: :original_product
 
+  has_many :events
+
   has_one :last_activity, class_name: "Contacts::LastActivity", dependent: :destroy
 end
 
@@ -50,4 +52,8 @@ end
 class Orders::LineItem < ActiveRecord::Base
   belongs_to :order, class_name: "Order"
   belongs_to :original_product, class_name: "Product"
+end
+
+class Event < ActiveRecord::Base
+  belongs_to :contact, optional: true
 end


### PR DESCRIPTION
This PR adds a few things:
1. Enables flat-queries to work for multi-database relationships. This will run a separate query against the associatied model returning a list of primary object ids. These ids are then passed into the rest of the flat query. The inner query will need to be run for each copy of the condition in use. So if you have 3 conditions in your filter referencing a multi-db lookup that means in order to construct the query refine has to make 3 separate queries to get the list of ids and return back to the primary query. Also be aware that this might lead to huge lists of ids for larger data sets
2. Adds mocha to test infrastructure so we could stub the `condiiton_uses_different_database?` method
3. Adds a full test for multi-db queries that didn't exist at all before.