### PR TITLE
Supporting non id associations in flat query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.13.7
+  * Adds an is_flat_query instance variable to conditions so that custom overridden conditions can tell if they're being called with flat_query or regular make_query
+  * Fixes a typo with multi-db method name
+  * Adds test for non-id association with datetime
+  * Abstracts some of the flat_query methods for dry purpose
 ### 2.13.6
   * Adds flat_query support for multi-db associations
 ### 2.13.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.13.6)
+    refine-rails (2.13.7)
       rails (>= 6.0)
 
 GEM

--- a/app/models/refine/conditions/condition.rb
+++ b/app/models/refine/conditions/condition.rb
@@ -16,7 +16,7 @@ module Refine::Conditions
     include SupportsFlatQueries
 
     attr_reader :ensurances, :before_validations, :clause, :filter
-    attr_accessor :display, :id, :is_refinement, :attribute
+    attr_accessor :display, :id, :is_refinement, :attribute, :is_flat_query
 
     I18N_PREFIX = "refine.refine_blueprints.condition."
 

--- a/app/models/refine/conditions/supports_flat_queries.rb
+++ b/app/models/refine/conditions/supports_flat_queries.rb
@@ -94,7 +94,7 @@ module Refine::Conditions
       apply_flat_relational_condition(instance: instance, relation: relation, through_reflection: through_reflection, input: input, table: table, query: query, inverse_clause: inverse_clause, forced_id: forced_id)
     end
 
-    def apply_flat_relational_condition(instance:, relation:, through_reflection:, input:, table:, query:, inverse_clause:, forced_id: nil)
+    def apply_flat_relational_condition(instance:, relation:, through_reflection:, input:, table:, query:, inverse_clause:, forced_id: false)
       unless instance
         raise "Relationship does not exist for #{relation}."
       end

--- a/app/models/refine/conditions/supports_flat_queries.rb
+++ b/app/models/refine/conditions/supports_flat_queries.rb
@@ -18,6 +18,7 @@ module Refine::Conditions
     # This is mostly a copy of the `apply` method from the Condition module, but avoids recursion and the pending_subquery system
     def apply_flat(input, table, initial_query, inverse_clause=false)
       table ||= filter.table
+      @is_flat_query = true
       # Ensurance validations are checking the developer configured correctly
       run_ensurance_validations
       # Allow developer to modify user input
@@ -73,20 +74,27 @@ module Refine::Conditions
       end
 
       through_reflection = instance
+      forced_id = false
 
       # TODO - make sure we're accounting for refinements
       if @attribute == "id"
         # We're referencing a primary key ID, so we dont need the final join table and
         # can just reference the foreign key of the previous step in the relation chain
         through_reflection = get_through_reflection(instance: instance, relation: decompose_attribute[0])
-        add_pending_joins_if_needed(instance: instance, reflection: through_reflection, input: input)
-        # TODO - this is not the right long-term place for this.
-        filter.needs_distinct = true
-        @attribute = get_foreign_key_from_relation(instance: instance, reflection: through_reflection)
-      # else
-      #   puts "TODO - not referencing an ID in attribute"
+        unless condition_uses_different_database?(through_reflection.klass, query.model)
+          forced_id = true
+          @attribute = get_foreign_key_from_relation(instance: instance, reflection: through_reflection)
+        end
       end
 
+      unless condition_uses_different_database?(through_reflection.klass, query.model)
+        add_pending_joins_if_needed(instance: instance, reflection: through_reflection, input: input)
+      end
+      # TODO - this is not the right long-term place for this.
+      apply_flat_relational_condition(instance: instance, relation: relation, through_reflection: through_reflection, input: input, table: table, query: query, inverse_clause: inverse_clause, forced_id: forced_id)
+    end
+
+    def apply_flat_relational_condition(instance:, relation:, through_reflection:, input:, table:, query:, inverse_clause:, forced_id: nil)
       unless instance
         raise "Relationship does not exist for #{relation}."
       end
@@ -94,13 +102,18 @@ module Refine::Conditions
       relation_table_being_queried = through_reflection.klass.arel_table
       relation_class = through_reflection.klass
 
-      instance = get_reflection_object(query, relation)
+      instance = get_reflection_object(query, relation) if forced_id
+
       key_1 = key_1(instance)
       key_2 = key_2(instance)
-      if condiiton_uses_different_database?(relation_class, query.model)
+      if condition_uses_different_database?(relation_class, query.model)
         nodes = handle_flat_cross_database_condition(input: input, table: table, relation_class: relation_class, relation_table_being_queried: relation_table_being_queried, inverse_clause: inverse_clause, key_1: key_1, key_2: key_2)  
       else
-        nodes = apply(input, relation_table_being_queried, query, inverse_clause, key_2)
+        if forced_id
+          nodes = apply(input, relation_table_being_queried, query, inverse_clause, key_2)
+        else
+          nodes = apply(input, relation_table_being_queried, query, inverse_clause)
+        end
       end
 
       if !is_refinement && has_any_refinements?
@@ -109,7 +122,6 @@ module Refine::Conditions
         nodes = nodes.and(refined_node) if refined_node
       end
       nodes
-
     end
 
     # When we need to go to another DB for the relation. We need to do a separate query to get the IDS of
@@ -148,6 +160,7 @@ module Refine::Conditions
       # If we already are tracking the relation with a left joins, don't overwrite it
       # puts "adding a pending join for relation: #{relation} with join type: #{join_type}"
       unless join_type == :inner && filter.pending_joins[relation] == :left
+        filter.needs_distinct = true
         filter.pending_joins[relation] = join_type
       end
     end
@@ -161,7 +174,7 @@ module Refine::Conditions
       end
     end
 
-    def condiiton_uses_different_database?(current_model, parent_model)
+    def condition_uses_different_database?(current_model, parent_model)
       # Are the queries on different databases?
       parent_model.connection_db_config.configuration_hash != current_model.connection_db_config.configuration_hash
     end

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.13.6"
+    VERSION = "2.13.7"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.13.6",
+  "version": "2.13.7",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",

--- a/test/refine/models/filters/flat_query_tools/flat_query_cross_db_test.rb
+++ b/test/refine/models/filters/flat_query_tools/flat_query_cross_db_test.rb
@@ -25,7 +25,7 @@ describe Refine::Filter do
     it "properly constructs the initial query before applying the condition" do
       initial_query = Contact.all
       filter = create_filter(event_blueprint)
-      Refine::Conditions::Condition.any_instance.stubs(:condiiton_uses_different_database?).returns(true)
+      Refine::Conditions::Condition.any_instance.stubs(:condition_uses_different_database?).returns(true)
       executed_queries = []
       original_execute = Event.connection.method(:execute)
 
@@ -48,7 +48,7 @@ describe Refine::Filter do
       initial_query = Contact.all
       Event.create(source_id: 1, contact_id: 50)
       filter = create_filter(event_blueprint)
-      Refine::Conditions::Condition.any_instance.stubs(:condiiton_uses_different_database?).returns(true)
+      Refine::Conditions::Condition.any_instance.stubs(:condition_uses_different_database?).returns(true)
 
       expected_sql = <<-SQL.squish
         SELECT `contacts`.* FROM `contacts` 
@@ -62,7 +62,7 @@ describe Refine::Filter do
       Event.create(source_id: 1, contact_id: 50)
       Event.create(source_id: 1, contact_id: 51)
       filter = create_filter(event_blueprint)
-      Refine::Conditions::Condition.any_instance.stubs(:condiiton_uses_different_database?).returns(true)
+      Refine::Conditions::Condition.any_instance.stubs(:condition_uses_different_database?).returns(true)
 
       expected_sql = <<-SQL.squish
         SELECT `contacts`.* FROM `contacts` 
@@ -77,7 +77,7 @@ describe Refine::Filter do
       Event.create(source_id: 2, contact_id: 51)
       Event.create(source_id: 5, contact_id: 50)
       filter = create_filter(multi_event_blueprint)
-      Refine::Conditions::Condition.any_instance.stubs(:condiiton_uses_different_database?).returns(true)
+      Refine::Conditions::Condition.any_instance.stubs(:condition_uses_different_database?).returns(true)
 
       expected_sql = <<-SQL.squish
         SELECT `contacts`.* FROM `contacts` 

--- a/test/refine/models/filters/flat_query_tools/flat_query_last_activity_test.rb
+++ b/test/refine/models/filters/flat_query_tools/flat_query_last_activity_test.rb
@@ -1,0 +1,117 @@
+require "test_helper"
+require "support/refine/test_double_filter"
+require "support/refine/contact_complex_relationships"
+require "refine/invalid_filter_error"
+
+describe Refine::Filter do
+  include FilterTestHelper
+
+  around do |test|
+    ApplicationRecord.connection.execute("CREATE TABLE contacts (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE contacts_applied_tags (id bigint primary key, contact_id bigint, tag_id bigint);")
+    ApplicationRecord.connection.execute("CREATE TABLE contacts_tags (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE contacts_last_activities (id bigint primary key, last_activity_at datetime);")
+    test.call
+    ApplicationRecord.connection.execute("DROP TABLE contacts, contacts_applied_tags, contacts_tags, contacts_last_activities;")
+  end
+
+  describe "get_flat_query" do
+    it "referencing an attribute on a related table thats not the primary key generates a proper query" do
+      initial_query = Contact.all
+      filter = create_filter(last_activity_criteria)
+
+      expected_sql = <<-SQL.squish
+        SELECT DISTINCT `contacts`.* FROM `contacts` 
+          INNER JOIN `contacts_last_activities` ON `contacts_last_activities`.`contact_id` = `contacts`.`id` 
+          WHERE ((`contacts_last_activities`.`last_activity_at` BETWEEN '2020-01-01 00:00:00' AND '2020-01-01 23:59:59'))
+      SQL
+      assert_equal expected_sql, filter.get_flat_query.to_sql
+    end
+
+    it "combining with another relational condition still generates the correct query" do
+      initial_query = Contact.all
+      filter = create_filter(last_activity_criteria_and_tag)
+
+      expected_sql = <<-SQL.squish
+        SELECT DISTINCT `contacts`.* FROM `contacts` 
+          INNER JOIN `contacts_last_activities` ON `contacts_last_activities`.`contact_id` = `contacts`.`id` 
+          INNER JOIN `contacts_applied_tags` ON `contacts_applied_tags`.`contact_id` = `contacts`.`id` 
+          WHERE ((`contacts_last_activities`.`last_activity_at` BETWEEN '2020-01-01 00:00:00' AND '2020-01-01 23:59:59')) AND ((`contacts_applied_tags`.`tag_id` = 4))
+      SQL
+      assert_equal expected_sql, filter.get_flat_query.to_sql
+    end
+  end
+
+  def create_filter(blueprint=nil)
+    tag_options = [{id: "1", display: "tag1"}, {id: "2", display: "tag2"}, {id: "3", display: "tag3"}, {id: "4", display: "tag4"}]
+    BlankTestFilter.new(blueprint,
+      Contact.all,
+      [
+        Refine::Conditions::TextCondition.new("text_field_value"),
+        Refine::Conditions::OptionCondition.new("tags.id").with_options(proc { tag_options }),
+        Refine::Conditions::DateWithTimeCondition.new("last_activity.last_activity_at")
+      ],
+      Contact.arel_table)
+  end
+
+  def last_activity_criteria
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "last_activity.last_activity_at",
+      input: {
+        clause: "eq",
+        date1: "2020-01-01"
+      }
+    }]
+  end
+
+  def last_activity_criteria_and_tag
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "last_activity.last_activity_at",
+      input: {
+        clause: "eq",
+        date1: "2020-01-01"
+      }
+    }, { # conjunction
+      depth: 0,
+      type: "conjunction",
+      word: "and"
+    }, {
+      depth: 0,
+      type: "criterion",
+      condition_id: "tags.id",
+      input: {
+        clause: "eq",
+        selected: ["4"]
+      }
+    }]
+  end
+
+  def two_tag_criteria
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "tags.id",
+      input: {
+        clause: "in",
+        selected: ["1", "2"]
+      }
+    }, { # conjunction
+      depth: 0,
+      type: "conjunction",
+      word: "and"
+    }, {
+      depth: 0,
+      type: "criterion",
+      condition_id: "tags.id",
+      input: {
+        clause: "eq",
+        selected: ["4"]
+      }
+    }]
+  end
+
+end


### PR DESCRIPTION
This mostly just adds the use case to the relational flat query construction where the attribute isn't an "id". 
* Adds an is_flat_query instance variable to conditions so that custom overridden conditions can tell if they're being called with flat_query or regular make_query
* Fixes a typo with multi-db method name
* Adds test for non-id association with datetime
* Abstracts some of the flat_query methods for dry purpose