### PR TITLE
Cleaning up other relations flat query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.13.8
+  * Each flat-query condition now loops to more deeply support nested attributes. For each nest a new join param will be added to the query
+  * simplified some of the variable usage and params being passed around to remove things unnecessary.
+  * adds several tests for nested attributes using a theoretical custom_attributes model as example
 ### 2.13.7
   * Adds an is_flat_query instance variable to conditions so that custom overridden conditions can tell if they're being called with flat_query or regular make_query
   * Fixes a typo with multi-db method name

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.13.7)
+    refine-rails (2.13.8)
       rails (>= 6.0)
 
 GEM

--- a/app/models/refine/conditions/supports_flat_queries.rb
+++ b/app/models/refine/conditions/supports_flat_queries.rb
@@ -66,7 +66,6 @@ module Refine::Conditions
 
         instance = model_class.reflect_on_association(relation.to_sym)
 
-        # TODO - make sure we're accounting for refinements
         if @attribute == "id"
           # We're referencing a primary key ID, so we dont need the final join table and
           # can just reference the foreign key of the previous step in the relation chain

--- a/app/models/refine/conditions/supports_flat_queries.rb
+++ b/app/models/refine/conditions/supports_flat_queries.rb
@@ -97,8 +97,6 @@ module Refine::Conditions
         add_pending_joins_if_needed(input: input, joins_array: condition_joins)
       end
 
-      puts "Passing into apply_flat_relational_condition with \ninstance: #{instance.inspect},\nrelation: #{relation},\nthrough_reflection: #{through_reflection.inspect},\nforced_id: #{forced_id}"
-
       apply_flat_relational_condition(instance: instance, relation: relation, through_reflection: through_reflection, input: input, query: query, inverse_clause: inverse_clause, forced_id: forced_id)
     end
 

--- a/app/models/refine/conditions/supports_flat_queries.rb
+++ b/app/models/refine/conditions/supports_flat_queries.rb
@@ -29,14 +29,12 @@ module Refine::Conditions
       # TODO Determine right place to set the clause
       validate_user_input(input)
       if input.dig(:filter_refinement).present?
-        # TODO - Handle refinements. Currently not working for flat queries because its dependent on the pending_subquery system
 
         filter_condition = call_proc_if_callable(@filter_refinement_proc)
         # Set the filter on the filter_condition to be the current_condition's filter
         filter_condition.set_filter(filter)
         filter_condition.is_refinement = true
 
-        # Applying the filter condition will modify pending relationship subqueries in place
         filter_condition.apply(input.dig(:filter_refinement), table, initial_query)
         input.delete(:filter_refinement)
       end

--- a/app/models/refine/conditions/supports_flat_queries.rb
+++ b/app/models/refine/conditions/supports_flat_queries.rb
@@ -55,59 +55,83 @@ module Refine::Conditions
     end
 
     def handle_flat_relational_condition(input:, table:, query:, inverse_clause:)
-      # Split on first .
-      decompose_attribute = @attribute.split(".", 2)
-      # Attribute now is the back half of the initial attribute
-      @attribute = decompose_attribute[1]
-      # Relation to be handled
-      relation = decompose_attribute[0]
+      model_class = query.model
+      condition_joins = []
+      while @attribute.include?(".")
+        forced_id = false
+        # Split on first .
+        decompose_attribute = @attribute.split(".", 2)
+        # Attribute now is the back half of the initial attribute
+        @attribute = decompose_attribute[1]
+        # Relation to be handled
+        relation = decompose_attribute[0]
 
-     
-      # Get the Reflection object which defines the relationship between query and relation
-      # First iteration pull relationship using base query which responds to model.
-      instance = if query.respond_to? :model
-        query.model.reflect_on_association(relation.to_sym)
-      else
-        # When query is sent in as subquery (recursive) the query object is the model class pulled from the
-        # previous instance value
-        query.reflect_on_association(relation.to_sym)
-      end
+        instance = model_class.reflect_on_association(relation.to_sym)
 
-      through_reflection = instance
-      forced_id = false
-
-      # TODO - make sure we're accounting for refinements
-      if @attribute == "id"
-        # We're referencing a primary key ID, so we dont need the final join table and
-        # can just reference the foreign key of the previous step in the relation chain
-        through_reflection = get_through_reflection(instance: instance, relation: decompose_attribute[0])
-        unless condition_uses_different_database?(through_reflection.klass, query.model)
-          forced_id = true
-          @attribute = get_foreign_key_from_relation(instance: instance, reflection: through_reflection)
+        # TODO - make sure we're accounting for refinements
+        if @attribute == "id"
+          # We're referencing a primary key ID, so we dont need the final join table and
+          # can just reference the foreign key of the previous step in the relation chain
+          model_class = instance.class_name.safe_constantize
+          through_reflection = get_through_reflection(instance: instance, relation: relation)
+          unless condition_uses_different_database?(through_reflection.klass, query.model)
+            forced_id = true
+            @attribute = get_foreign_key_from_relation(instance: instance, reflection: through_reflection)
+            unless condition_uses_different_database?(model_class, query.model)
+              condition_joins << through_reflection.name
+            end
+          end
+        else
+          # Track the loop iteration of needing joins.
+          # The resulting array will be used to construct a nested joins statement
+          # IE: [forms_submissions, forms_submissions_answers] will later be converted to forms_submissions: {forms_submissions_answers: {}}
+          unless condition_uses_different_database?(model_class, query.model)
+            condition_joins << relation
+          end
         end
+        model_class = instance.class_name.safe_constantize
+       
+      end # End of while loop
+
+      if condition_joins.any?
+        add_pending_joins_if_needed(input: input, joins_array: condition_joins)
       end
 
-      unless condition_uses_different_database?(through_reflection.klass, query.model)
-        add_pending_joins_if_needed(instance: instance, reflection: through_reflection, input: input)
-      end
-      # TODO - this is not the right long-term place for this.
-      apply_flat_relational_condition(instance: instance, relation: relation, through_reflection: through_reflection, input: input, table: table, query: query, inverse_clause: inverse_clause, forced_id: forced_id)
+      puts "Passing into apply_flat_relational_condition with \ninstance: #{instance.inspect},\nrelation: #{relation},\nthrough_reflection: #{through_reflection.inspect},\nforced_id: #{forced_id}"
+
+      apply_flat_relational_condition(instance: instance, relation: relation, through_reflection: through_reflection, input: input, query: query, inverse_clause: inverse_clause, forced_id: forced_id)
     end
 
-    def apply_flat_relational_condition(instance:, relation:, through_reflection:, input:, table:, query:, inverse_clause:, forced_id: false)
+    # apply_flat_relational_condition
+    # instance: The reflection object for the relationship
+    # relation: The name of the relationship
+    # through_reflection: The reflection object for the through relationship if applicable. Might be nil
+    # input: The user input for the condition
+    # query: The base query the condition is being applied to
+    # inverse_clause: Whether to invert the clause
+    # forced_id: Whether to force the ID of the instance to be used. This is used when the condition is referencing a primary key
+    def apply_flat_relational_condition(instance:, relation:, through_reflection:, input:,  query:, inverse_clause:, forced_id: false)
       unless instance
         raise "Relationship does not exist for #{relation}."
       end
 
-      relation_table_being_queried = through_reflection.klass.arel_table
-      relation_class = through_reflection.klass
+      if through_reflection
+        # If through reflection is passed in (due to an association only referencing the id)
+        # use that to get the table and class
+        relation_table_being_queried = through_reflection.klass.arel_table
+        relation_class = through_reflection.klass
+      else
+        # Otherwise, use the instance to get the table and class.
+        relation_table_being_queried = instance.class_name.safe_constantize&.arel_table
+        relation_class = instance.class_name.safe_constantize
+      end
 
       instance = get_reflection_object(query, relation) if forced_id
 
       key_1 = key_1(instance)
       key_2 = key_2(instance)
       if condition_uses_different_database?(relation_class, query.model)
-        nodes = handle_flat_cross_database_condition(input: input, table: table, relation_class: relation_class, relation_table_being_queried: relation_table_being_queried, inverse_clause: inverse_clause, key_1: key_1, key_2: key_2)  
+        nodes = handle_flat_cross_database_condition(root_model: query.model, input: input, relation_class: relation_class, relation_table_being_queried: relation_table_being_queried, inverse_clause: inverse_clause, key_1: key_1, key_2: key_2)  
       else
         if forced_id
           nodes = apply(input, relation_table_being_queried, query, inverse_clause, key_2)
@@ -126,7 +150,8 @@ module Refine::Conditions
 
     # When we need to go to another DB for the relation. We need to do a separate query to get the IDS of
     # the records matching the condition that will then be passed into the primary query.
-    def handle_flat_cross_database_condition(input:, table:, relation_class:, relation_table_being_queried:, inverse_clause:, key_1:, key_2:)
+    def handle_flat_cross_database_condition(root_model:, input:, relation_class:, relation_table_being_queried:, inverse_clause:, key_1:, key_2:)
+      table = root_model.arel_table
       relational_query = relation_class.select(key_2).arel
       node = apply(input, relation_table_being_queried, relation_class, inverse_clause)
       relational_query = relational_query.where(node)
@@ -156,21 +181,22 @@ module Refine::Conditions
       child_foreign_key
     end
 
-    def add_pending_join(relation, join_type=:inner)
+    def add_pending_join(joins_array, join_type=:inner)
+      relation = joins_array.first
+      joins_block = joins_array.reverse.inject({}) { |a, n| { n.to_sym => a } }
       # If we already are tracking the relation with a left joins, don't overwrite it
-      # puts "adding a pending join for relation: #{relation} with join type: #{join_type}"
-      unless join_type == :inner && filter.pending_joins[relation] == :left
+      unless join_type == :inner && filter.pending_joins[relation] && filter.pending_joins[relation][:type] == :left
         filter.needs_distinct = true
-        filter.pending_joins[relation] = join_type
+        filter.pending_joins[relation] = { type: join_type, joins_block: joins_block}.compact
       end
     end
 
-    def add_pending_joins_if_needed(instance:, reflection:, input:)
+    def add_pending_joins_if_needed(input:, joins_array:)
       # Determine if we need to do left-joins due to the clause needing to include null values
       if(input && LEFT_JOIN_CLAUSES.include?(input[:clause]))
-        add_pending_join(reflection.name, :left)
+        add_pending_join(joins_array, :left)
       else
-        add_pending_join(reflection.name, :inner)
+        add_pending_join(joins_array, :inner)
       end
     end
 

--- a/app/models/refine/flat_query_tools.rb
+++ b/app/models/refine/flat_query_tools.rb
@@ -76,18 +76,15 @@ module Refine
     def apply_pending_joins
       if pending_joins.present?
         join_count = 0
-        pending_joins.each do |relation, join_type|
-          if join_type == :left
-            @relation = @relation.left_joins(relation.to_sym).distinct
+        pending_joins.each do |relation, join_data|
+          if join_data[:type] == :left
+            @relation = @relation.left_joins(join_data[:joins_block]).distinct
           else
-            @relation = @relation.joins(relation.to_sym)
+            @relation = @relation.joins(join_data[:joins_block]).distinct
           end
           join_count += 1
         end
 
-        if join_count > 1
-          @relation = @relation.distinct
-        end
       end
     end
 

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.13.7"
+    VERSION = "2.13.8"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.13.7",
+  "version": "2.13.8",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",

--- a/test/refine/models/filters/flat_query_tools/flat_query_forms_submissions_db_test.rb
+++ b/test/refine/models/filters/flat_query_tools/flat_query_forms_submissions_db_test.rb
@@ -1,0 +1,152 @@
+require "test_helper"
+require "support/refine/test_double_filter"
+require "support/refine/contact_complex_relationships"
+require "refine/invalid_filter_error"
+
+describe Refine::Filter do
+  include FilterTestHelper
+
+  around do |test|
+    ApplicationRecord.connection.execute("CREATE TABLE contacts (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE forms_submissions (id bigint primary key, contact_id bigint);")
+    ApplicationRecord.connection.execute("CREATE TABLE forms_submissions_answers (id bigint primary key, submission_id bigint, field_id bigint, fields_option_id bigint);")
+    ApplicationRecord.connection.execute("CREATE TABLE forms_submissions_answers_selected_options (id bigint primary key, answer_id bigint, fields_option_id bigint);")
+    ApplicationRecord.connection.execute("CREATE TABLE forms_fields (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE forms_answers (id bigint primary key);")
+    ApplicationRecord.connection.execute("CREATE TABLE contacts_applied_tags (id bigint primary key, contact_id bigint, tag_id bigint);")
+    ApplicationRecord.connection.execute("CREATE TABLE contacts_tags (id bigint primary key);")
+    test.call
+    ApplicationRecord.connection.execute("DROP TABLE contacts, forms_submissions, forms_submissions_answers, forms_submissions_answers_selected_options, forms_fields, forms_answers, contacts_applied_tags, contacts_tags;")
+  end
+
+  describe "get_flat_query" do
+    it "referencing an attribute on a related table thats not the primary key generates a proper query" do
+      initial_query = Contact.all
+      filter = create_filter(text_custom_field_criteria)
+
+      expected_sql = <<-SQL.squish
+        SELECT DISTINCT `contacts`.* FROM `contacts`
+          INNER JOIN `forms_submissions` ON `forms_submissions`.`id` = `contacts`.`custom_attributes_id`
+          INNER JOIN `forms_submissions_answers` ON `forms_submissions_answers`.`submission_id` = `forms_submissions`.`id`
+          WHERE ((`forms_submissions_answers`.`entry` = 'test'))
+      SQL
+      assert_equal expected_sql, filter.get_flat_query.to_sql
+    end
+
+    it "single-select custom attributes generate the proper query" do
+      initial_query = Contact.all
+      filter = create_filter(option_custom_field_criteria)
+
+      expected_sql = <<-SQL.squish
+        SELECT DISTINCT `contacts`.* FROM `contacts` 
+          INNER JOIN `forms_submissions` ON `forms_submissions`.`id` = `contacts`.`custom_attributes_id` 
+          INNER JOIN `forms_submissions_answers` ON `forms_submissions_answers`.`submission_id` = `forms_submissions`.`id` 
+          WHERE ((`forms_submissions_answers`.`fields_option_id` IN (2, 3)))
+      SQL
+      assert_equal expected_sql, filter.get_flat_query.to_sql
+    end
+
+    it "multi-select custom attributes generate the proper query" do
+      initial_query = Contact.all
+      filter = create_filter(option_multi_custom_field_criteria)
+
+      expected_sql = <<-SQL.squish
+        SELECT DISTINCT `contacts`.* FROM `contacts` 
+          INNER JOIN `forms_submissions` ON `forms_submissions`.`id` = `contacts`.`custom_attributes_id`
+          INNER JOIN `forms_submissions_answers` ON `forms_submissions_answers`.`submission_id` = `forms_submissions`.`id`
+          INNER JOIN `forms_submissions_answers_selected_options` ON `forms_submissions_answers_selected_options`.`answer_id` = `forms_submissions_answers`.`id`
+          WHERE ((`forms_submissions_answers_selected_options`.`fields_option_id` IN (1, 2)))
+      SQL
+      assert_equal expected_sql, filter.get_flat_query.to_sql
+    end
+
+    it "combining different custom attributes and tags generate the proper query" do
+      initial_query = Contact.all
+      filter = create_filter(multiple_conditions_criteria)
+
+      expected_sql = <<-SQL.squish
+        SELECT DISTINCT `contacts`.* FROM `contacts`
+          INNER JOIN `forms_submissions` ON `forms_submissions`.`id` = `contacts`.`custom_attributes_id`
+          INNER JOIN `forms_submissions_answers` ON `forms_submissions_answers`.`submission_id` = `forms_submissions`.`id`
+          INNER JOIN `contacts_applied_tags` ON `contacts_applied_tags`.`contact_id` = `contacts`.`id`
+          WHERE ((`forms_submissions_answers`.`fields_option_id` IN (2, 3))) AND ((`contacts_applied_tags`.`tag_id` IN (1, 2)))
+      SQL
+      assert_equal expected_sql, filter.get_flat_query.to_sql
+    end
+  end
+
+  def create_filter(blueprint=nil)
+    field_options = [{id: "1", display: "field1"}, {id: "2", display: "field2"}, {id: "3", display: "field3"}, {id: "4", display: "field4"}]
+    selected_options = [{id: "1", display: "selected1"}, {id: "2", display: "selected2"}, {id: "3", display: "selected3"}, {id: "4", display: "selected4"}]
+    BlankTestFilter.new(blueprint,
+      Contact.all,
+      [
+        Refine::Conditions::TextCondition.new("custom_attributes.answers.entry"),
+        Refine::Conditions::OptionCondition.new("custom_attributes.answers.selected_options.fields_option_id").with_options(proc { field_options }),
+        Refine::Conditions::OptionCondition.new("custom_attributes.answers.fields_option_id").with_options(proc { selected_options }),
+        Refine::Conditions::OptionCondition.new("tags.id").with_options(proc { field_options }),
+      ],
+      Contact.arel_table)
+  end
+
+  def text_custom_field_criteria
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "custom_attributes.answers.entry",
+      input: {
+        clause: "eq",
+        value: "test"
+      }
+    }]
+  end
+
+  def option_custom_field_criteria
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "custom_attributes.answers.fields_option_id",
+      input: {
+        clause: "in",
+        selected: ["2", "3"]
+      }
+    }]
+  end
+
+  def option_multi_custom_field_criteria
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "custom_attributes.answers.selected_options.fields_option_id",
+      input: {
+        clause: "in",
+        selected: ["1", "2"]
+      }
+    }]
+  end
+
+  def multiple_conditions_criteria
+    [{
+      depth: 0,
+      type: "criterion",
+      condition_id: "custom_attributes.answers.fields_option_id",
+      input: {
+        clause: "in",
+        selected: ["2", "3"]
+      }
+    }, { # conjunction
+      depth: 0,
+      type: "conjunction",
+      word: "and"
+    }, {
+      depth: 0,
+      type: "criterion",
+      condition_id: "tags.id",
+      input: {
+        clause: "in",
+        selected: ["1", "2"]
+      } 
+    }]
+  end
+
+end

--- a/test/support/refine/contact_complex_relationships.rb
+++ b/test/support/refine/contact_complex_relationships.rb
@@ -12,6 +12,8 @@ class Contact < ActiveRecord::Base
   has_many :events
 
   has_one :last_activity, class_name: "Contacts::LastActivity", dependent: :destroy
+
+  belongs_to :custom_attributes, class_name: "Forms::Submission", optional: true
 end
 
 module Contacts
@@ -22,11 +24,11 @@ end
 
 class Contacts::AppliedTag < ActiveRecord::Base
   belongs_to :contact, touch: true
-  belongs_to :tag, class_name: "Tag"
+  belongs_to :tag, class_name: "Contacts::Tag"
 end
 
 class Contacts::Tag < ActiveRecord::Base
-  has_many :applied_tags, class_name: "AppliedTag", dependent: :destroy
+  has_many :applied_tags, class_name: "Contacts::AppliedTag", dependent: :destroy
   has_many :contacts, through: :applied_tags
 end
 
@@ -57,3 +59,57 @@ end
 class Event < ActiveRecord::Base
   belongs_to :contact, optional: true
 end
+
+
+module Forms
+  def self.table_name_prefix
+    "forms_"
+  end
+end
+
+class Forms::Submission < ActiveRecord::Base
+  belongs_to :contact, optional: true
+
+  has_many :answers, class_name: "Forms::Submissions::Answer"
+end
+
+module Forms::Submissions
+  def self.table_name_prefix
+    "forms_submissions_"
+  end
+end
+
+class Forms::Submissions::Answer < ActiveRecord::Base
+  belongs_to :submission, class_name: "Forms::Submission"
+  belongs_to :field, class_name: "Forms::Field"
+  belongs_to :fields_option, class_name: "Forms::Fields::Option", optional: true
+  has_many :selected_options, class_name: "Forms::Submissions::Answers::SelectedOption", dependent: :destroy, foreign_key: :answer_id, inverse_of: :answer
+end
+
+module Forms::Submissions::Answers
+  def self.table_name_prefix
+    "forms_submissions_answers_"
+  end
+end
+
+class Forms::Submissions::Answers::SelectedOption < ActiveRecord::Base
+  belongs_to :answer, class_name: "Forms::Submissions::Answer", inverse_of: :selected_options
+  belongs_to :field_option, class_name: "Forms::Fields::Option"
+end
+
+module Forms::Fields
+  def self.table_name_prefix
+    "forms_fields_"
+  end
+end
+
+class Forms::Field < ActiveRecord::Base
+  has_many :answers, class_name: "Forms::Submissions::Answer", foreign_key: :field_id, inverse_of: :field
+  has_many :options, class_name: "Forms::Fields::Option", foreign_key: :field_id, inverse_of: :field
+end
+
+class Forms::Fields::Option < ActiveRecord::Base
+  belongs_to :field, class_name: "Forms::Field"
+end
+
+


### PR DESCRIPTION
Adds support for more deeply nested associations in flat query.
* Adds looping and more support for complex joins. Uses the same syntax as ActiveRecord's `joins` hash paraams
* Adds several tests to cover the additional complexity
* Cleans up overly complex logic in flat-query