### PR TITLE
providing ability to manage flat_query on a filter class basis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.14.0
+  * Making flat_query an includable module for implementing filter classes
+  * Adds a new method for filter classes with `FlatQueryTools` included. `can_use_flat_query?` which uses smart defaults and can be overridden
+  * branched the standard `get_query` method to go to `get_flat_query` or the sub-select `get_complex_query` based on whether module is included and `can_use_flat_query?` is set to true
 ### 2.13.8
   * Each flat-query condition now loops to more deeply support nested attributes. For each nest a new join param will be added to the query
   * simplified some of the variable usage and params being passed around to remove things unnecessary.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.13.8)
+    refine-rails (2.14.0)
       rails (>= 6.0)
 
 GEM
@@ -105,7 +105,7 @@ GEM
     mocha (2.7.1)
       ruby2_keywords (>= 0.0.5)
     mysql2 (0.5.6)
-    net-imap (0.5.6)
+    net-imap (0.5.8)
       date
       net-protocol
     net-pop (0.1.2)

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.13.8"
+    VERSION = "2.14.0"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.13.8",
+  "version": "2.14.0",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",

--- a/test/refine/models/filters/flat_query_tools/flat_query_cross_db_test.rb
+++ b/test/refine/models/filters/flat_query_tools/flat_query_cross_db_test.rb
@@ -91,7 +91,7 @@ describe Refine::Filter do
   def create_filter(blueprint=nil)
     tag_options = [{id: "1", display: "tag1"}, {id: "2", display: "tag2"}, {id: "3", display: "tag3"}, {id: "4", display: "tag4"}]
     event_source_options = [{id: "1", display: "source1"}, {id: "2", display: "source2"}, {id: "5", display: "source5"}]
-    BlankTestFilter.new(blueprint,
+    FlatQueryTestFilter.new(blueprint,
       Contact.all,
       [
         Refine::Conditions::TextCondition.new("text_field_value"),

--- a/test/refine/models/filters/flat_query_tools/flat_query_forms_submissions_db_test.rb
+++ b/test/refine/models/filters/flat_query_tools/flat_query_forms_submissions_db_test.rb
@@ -28,7 +28,7 @@ describe Refine::Filter do
         SELECT DISTINCT `contacts`.* FROM `contacts`
           INNER JOIN `forms_submissions` ON `forms_submissions`.`id` = `contacts`.`custom_attributes_id`
           INNER JOIN `forms_submissions_answers` ON `forms_submissions_answers`.`submission_id` = `forms_submissions`.`id`
-          WHERE ((`forms_submissions_answers`.`entry` = 'test'))
+          WHERE (`forms_submissions_answers`.`entry` = 'test')
       SQL
       assert_equal expected_sql, filter.get_flat_query.to_sql
     end
@@ -41,7 +41,7 @@ describe Refine::Filter do
         SELECT DISTINCT `contacts`.* FROM `contacts` 
           INNER JOIN `forms_submissions` ON `forms_submissions`.`id` = `contacts`.`custom_attributes_id` 
           INNER JOIN `forms_submissions_answers` ON `forms_submissions_answers`.`submission_id` = `forms_submissions`.`id` 
-          WHERE ((`forms_submissions_answers`.`fields_option_id` IN (2, 3)))
+          WHERE (`forms_submissions_answers`.`fields_option_id` IN (2, 3))
       SQL
       assert_equal expected_sql, filter.get_flat_query.to_sql
     end
@@ -55,7 +55,7 @@ describe Refine::Filter do
           INNER JOIN `forms_submissions` ON `forms_submissions`.`id` = `contacts`.`custom_attributes_id`
           INNER JOIN `forms_submissions_answers` ON `forms_submissions_answers`.`submission_id` = `forms_submissions`.`id`
           INNER JOIN `forms_submissions_answers_selected_options` ON `forms_submissions_answers_selected_options`.`answer_id` = `forms_submissions_answers`.`id`
-          WHERE ((`forms_submissions_answers_selected_options`.`fields_option_id` IN (1, 2)))
+          WHERE (`forms_submissions_answers_selected_options`.`fields_option_id` IN (1, 2))
       SQL
       assert_equal expected_sql, filter.get_flat_query.to_sql
     end
@@ -69,7 +69,7 @@ describe Refine::Filter do
           INNER JOIN `forms_submissions` ON `forms_submissions`.`id` = `contacts`.`custom_attributes_id`
           INNER JOIN `forms_submissions_answers` ON `forms_submissions_answers`.`submission_id` = `forms_submissions`.`id`
           INNER JOIN `contacts_applied_tags` ON `contacts_applied_tags`.`contact_id` = `contacts`.`id`
-          WHERE ((`forms_submissions_answers`.`fields_option_id` IN (2, 3))) AND ((`contacts_applied_tags`.`tag_id` IN (1, 2)))
+          WHERE (`forms_submissions_answers`.`fields_option_id` IN (2, 3)) AND (`contacts_applied_tags`.`tag_id` IN (1, 2))
       SQL
       assert_equal expected_sql, filter.get_flat_query.to_sql
     end
@@ -78,7 +78,7 @@ describe Refine::Filter do
   def create_filter(blueprint=nil)
     field_options = [{id: "1", display: "field1"}, {id: "2", display: "field2"}, {id: "3", display: "field3"}, {id: "4", display: "field4"}]
     selected_options = [{id: "1", display: "selected1"}, {id: "2", display: "selected2"}, {id: "3", display: "selected3"}, {id: "4", display: "selected4"}]
-    BlankTestFilter.new(blueprint,
+    FlatQueryTestFilter.new(blueprint,
       Contact.all,
       [
         Refine::Conditions::TextCondition.new("custom_attributes.answers.entry"),

--- a/test/refine/models/filters/flat_query_tools/flat_query_last_activity_test.rb
+++ b/test/refine/models/filters/flat_query_tools/flat_query_last_activity_test.rb
@@ -23,7 +23,7 @@ describe Refine::Filter do
       expected_sql = <<-SQL.squish
         SELECT DISTINCT `contacts`.* FROM `contacts` 
           INNER JOIN `contacts_last_activities` ON `contacts_last_activities`.`contact_id` = `contacts`.`id` 
-          WHERE ((`contacts_last_activities`.`last_activity_at` BETWEEN '2020-01-01 00:00:00' AND '2020-01-01 23:59:59'))
+          WHERE (`contacts_last_activities`.`last_activity_at` BETWEEN '2020-01-01 00:00:00' AND '2020-01-01 23:59:59')
       SQL
       assert_equal expected_sql, filter.get_flat_query.to_sql
     end
@@ -36,7 +36,7 @@ describe Refine::Filter do
         SELECT DISTINCT `contacts`.* FROM `contacts` 
           INNER JOIN `contacts_last_activities` ON `contacts_last_activities`.`contact_id` = `contacts`.`id` 
           INNER JOIN `contacts_applied_tags` ON `contacts_applied_tags`.`contact_id` = `contacts`.`id` 
-          WHERE ((`contacts_last_activities`.`last_activity_at` BETWEEN '2020-01-01 00:00:00' AND '2020-01-01 23:59:59')) AND ((`contacts_applied_tags`.`tag_id` = 4))
+          WHERE (`contacts_last_activities`.`last_activity_at` BETWEEN '2020-01-01 00:00:00' AND '2020-01-01 23:59:59') AND (`contacts_applied_tags`.`tag_id` = 4)
       SQL
       assert_equal expected_sql, filter.get_flat_query.to_sql
     end
@@ -44,7 +44,7 @@ describe Refine::Filter do
 
   def create_filter(blueprint=nil)
     tag_options = [{id: "1", display: "tag1"}, {id: "2", display: "tag2"}, {id: "3", display: "tag3"}, {id: "4", display: "tag4"}]
-    BlankTestFilter.new(blueprint,
+    FlatQueryTestFilter.new(blueprint,
       Contact.all,
       [
         Refine::Conditions::TextCondition.new("text_field_value"),

--- a/test/refine/models/filters/flat_query_tools/flat_query_tags_test.rb
+++ b/test/refine/models/filters/flat_query_tools/flat_query_tags_test.rb
@@ -26,7 +26,7 @@ describe Refine::Filter do
       expected_sql = <<-SQL.squish
         SELECT DISTINCT `contacts`.* FROM `contacts` 
           INNER JOIN `contacts_applied_tags` ON `contacts_applied_tags`.`contact_id` = `contacts`.`id` 
-          WHERE ((`contacts_applied_tags`.`tag_id` IN (1, 2))) AND ((`contacts_applied_tags`.`tag_id` = 4))
+          WHERE (`contacts_applied_tags`.`tag_id` IN (1, 2)) AND (`contacts_applied_tags`.`tag_id` = 4)
       SQL
       assert_equal expected_sql, filter.get_flat_query.to_sql
     end
@@ -35,7 +35,7 @@ describe Refine::Filter do
 
   def create_filter(blueprint=nil)
     tag_options = [{id: "1", display: "tag1"}, {id: "2", display: "tag2"}, {id: "3", display: "tag3"}, {id: "4", display: "tag4"}]
-    BlankTestFilter.new(blueprint,
+    FlatQueryTestFilter.new(blueprint,
       Contact.all,
       [
         Refine::Conditions::TextCondition.new("text_field_value"),

--- a/test/support/refine/filter_test_helper.rb
+++ b/test/support/refine/filter_test_helper.rb
@@ -1,5 +1,6 @@
 require "support/refine/blank_test_filter"
 require "support/refine/cf2_blank_test_filter"
+require "support/refine/flat_query_test_filter"
 
 module FilterTestHelper
   class TestDouble < ActiveRecord::Base

--- a/test/support/refine/flat_query_test_filter.rb
+++ b/test/support/refine/flat_query_test_filter.rb
@@ -1,0 +1,18 @@
+require "support/refine/filter_test_helper"
+
+class FlatQueryTestFilter < Refine::Filter
+  include Refine::FlatQueryTools
+  attr_accessor :conditions
+
+  def t(key, options = {})
+    I18n.t("#{key}", options)
+  end
+
+  def initialize(blueprint = nil, initial_query = FilterTestHelper::TestDouble.all, conditions = nil, table = FilterTestHelper::TestDouble.arel_table)
+    @table = table
+    @conditions = conditions
+    super(blueprint, initial_query)
+  end
+
+  attr_reader :table
+end


### PR DESCRIPTION
This makes flat_query more easily accessible by doing the following:
* Moves the FlatQueryTools module out of the Filter class. Instead, the implementing filter class should include it - and then flat_query will be enabled by default
* Creates a smart default method on filter called `can_use_flat_query?`. Can be extended to handle custom use cases
* Changes the standard `get_query` method to check `can_use_flat_query?` method and whether the FlatQueryTools module is included. If so, it uses flat_query. Otherwise it calls `get_complex_query` which is simply the sub-select path which is the standard default