### PR TITLE
Improvemnts to separate db flat query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.14.1
+  * Fixes bug with flat-query multi db query generation
 ### 2.14.0
   * Making flat_query an includable module for implementing filter classes
   * Adds a new method for filter classes with `FlatQueryTools` included. `can_use_flat_query?` which uses smart defaults and can be overridden

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.14.0)
+    refine-rails (2.14.1)
       rails (>= 6.0)
 
 GEM
@@ -73,7 +73,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
-    base64 (0.2.0)
+    base64 (0.3.0)
     builder (3.2.4)
     byebug (11.1.3)
     concurrent-ruby (1.1.10)
@@ -152,7 +152,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
-    rake (13.2.1)
+    rake (13.3.0)
     regexp_parser (2.6.0)
     rexml (3.2.5)
     rubocop (1.35.1)
@@ -187,7 +187,7 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.3.0)
-    websocket-driver (0.7.7)
+    websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/app/models/refine/conditions/supports_flat_queries.rb
+++ b/app/models/refine/conditions/supports_flat_queries.rb
@@ -150,9 +150,6 @@ module Refine::Conditions
       relational_query = relation_class.select(key_2).distinct.arel
       node = apply(input, relation_table_being_queried, relation_class, inverse_clause)
       relational_query = relational_query.where(node)
-      puts "Relational query: #{relational_query.to_sql}"
-      puts "Relational class: #{relation_class}"
-      puts "Relational db config: #{relation_class.connection_db_config.configuration_hash.inspect}"
       results = relation_class.find_by_sql(relational_query.to_sql)
       array_of_ids = results.map { |result| result.send(key_2) }
       if array_of_ids.length == 1

--- a/app/models/refine/conditions/supports_flat_queries.rb
+++ b/app/models/refine/conditions/supports_flat_queries.rb
@@ -90,7 +90,7 @@ module Refine::Conditions
        
       end # End of while loop
 
-      if condition_joins.any?
+      if condition_joins.any? && !condition_uses_different_database?(model_class, query.model)
         add_pending_joins_if_needed(input: input, joins_array: condition_joins)
       end
 
@@ -147,10 +147,14 @@ module Refine::Conditions
     # the records matching the condition that will then be passed into the primary query.
     def handle_flat_cross_database_condition(root_model:, input:, relation_class:, relation_table_being_queried:, inverse_clause:, key_1:, key_2:)
       table = root_model.arel_table
-      relational_query = relation_class.select(key_2).arel
+      relational_query = relation_class.select(key_2).distinct.arel
       node = apply(input, relation_table_being_queried, relation_class, inverse_clause)
       relational_query = relational_query.where(node)
-      array_of_ids = relation_class.connection.exec_query(relational_query.to_sql).rows.flatten
+      puts "Relational query: #{relational_query.to_sql}"
+      puts "Relational class: #{relation_class}"
+      puts "Relational db config: #{relation_class.connection_db_config.configuration_hash.inspect}"
+      results = relation_class.find_by_sql(relational_query.to_sql)
+      array_of_ids = results.map { |result| result.send(key_2) }
       if array_of_ids.length == 1
         nodes = table[:"#{key_1}"].eq(array_of_ids.first)
       else

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.14.0"
+    VERSION = "2.14.1"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",

--- a/test/refine/models/filters/flat_query_tools/flat_query_cross_db_test.rb
+++ b/test/refine/models/filters/flat_query_tools/flat_query_cross_db_test.rb
@@ -30,7 +30,7 @@ describe Refine::Filter do
       original_execute = Event.connection.method(:execute)
 
       expected_event_sql = <<-SQL.squish
-        SELECT `events`.`contact_id` FROM `events`
+        SELECT DISTINCT `events`.`contact_id` FROM `events`
           WHERE (`events`.`source_id` IN (1, 2))
       SQL
 
@@ -42,6 +42,7 @@ describe Refine::Filter do
 
       assert executed_queries.any? { |sql| sql.include?(expected_event_sql)  }, "Expected to find the event query in the executed queries: #{expected_event_sql}"
 
+      ActiveSupport::Notifications.unsubscribe(subscriber)
     end
 
     it "single check " do


### PR DESCRIPTION
The first attempt at supporting separate db lookups for flat query resulted in a strange issue where it would attempt to use the same DB instead. This attempts to address that. Also it adds DISTINCT to the array of ids returned to remove redundancies