### PR TITLE
Pass the refine.daterangepicker locale translation to the inline date picker partials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 2.15.0
+  * Adds the ability to pass localization to the date picker.
 ### 2.14.1
   * Fixes bug with flat-query multi db query generation
 ### 2.14.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    refine-rails (2.14.1)
+    refine-rails (2.15.0)
       rails (>= 6.0)
 
 GEM
@@ -105,7 +105,7 @@ GEM
     mocha (2.7.1)
       ruby2_keywords (>= 0.0.5)
     mysql2 (0.5.6)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)

--- a/app/views/refine/advanced_inline/inputs/_date_picker.html.erb
+++ b/app/views/refine/advanced_inline/inputs/_date_picker.html.erb
@@ -4,6 +4,7 @@
   data-refine--date-locale-value="<%= I18n.locale %>"
   data-refine--date-date-format-value="<%=  I18n.t("refine.date.formats.moment") %>"
   data-refine--date-datetime-format-value="<%= I18n.t("refine.time.formats.moment") %>"
+  data-refine--date-picker-locale-value="<%= I18n.t("refine.daterangepicker").deep_transform_keys { |k| k.to_s.camelize(:lower) }.to_json %>"
 >
   <input
     class="refine--input"

--- a/app/views/refine/inline/inputs/_date_picker.html.erb
+++ b/app/views/refine/inline/inputs/_date_picker.html.erb
@@ -4,6 +4,7 @@
   data-refine--date-locale-value="<%= I18n.locale %>"
   data-refine--date-date-format-value="<%=  I18n.t("refine.date.formats.moment") %>"
   data-refine--date-datetime-format-value="<%= I18n.t("refine.time.formats.moment") %>"
+  data-refine--date-picker-locale-value="<%= I18n.t("refine.daterangepicker").deep_transform_keys { |k| k.to_s.camelize(:lower) }.to_json %>"
 >
   <input
     class="refine--input"

--- a/lib/refine/rails/version.rb
+++ b/lib/refine/rails/version.rb
@@ -1,5 +1,5 @@
 module Refine
   module Rails
-    VERSION = "2.14.1"
+    VERSION = "2.15.0"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickfunnels/refine-stimulus",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "description": "Refine is a flexible query builder for your apps. It lets your users filter down to exactly what they're looking for. Completely configured on the backend.",
   "browserslist": [
     "defaults",


### PR DESCRIPTION
We are passing in the localization data in the blueprint date picker https://github.com/clickfunnels2/refine-rails/blob/main/app/views/refine/blueprints/clauses/_date_picker.html.erb#L7 but we were not doing this in any of the inline pickers. This change passes the `refine.daterangepicker` locale values to `daterangepicker`.